### PR TITLE
Fix WebView Infinite Loading

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/home/HomeScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/home/HomeScreen.kt
@@ -13,14 +13,18 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 import com.google.accompanist.insets.navigationBarsPadding
 import com.google.accompanist.insets.statusBarsPadding
-import kotlinx.coroutines.flow.collect
 import soy.gabimoreno.R
 import soy.gabimoreno.core.normalizeText
 import soy.gabimoreno.presentation.navigation.deeplink.DeepLinkEpisodeNumber
@@ -41,8 +45,6 @@ fun HomeScreen(
     val scrollState = rememberLazyListState()
     val homeViewModel = ViewModelProvider.homeViewModel
     val viewState = homeViewModel.viewState
-
-    var encodedUrl by remember { mutableStateOf("") }
 
     LaunchedEffect(Unit) {
         homeViewModel.onViewScreen()
@@ -126,8 +128,7 @@ fun HomeScreen(
                                     homeViewModel.onDeepLinkReceived(episodeId, episode.title)
                                     onDeepLinkReceived(episodeId)
                                 } else {
-                                    val url = DeepLinkUrl.value
-                                    url?.let {
+                                    DeepLinkUrl.value?.let { url ->
                                         DeepLinkUrl.value = null
                                         homeViewModel.onShowWebViewClicked(url)
                                     }
@@ -155,11 +156,14 @@ fun HomeScreen(
     LaunchedEffect(Unit) {
         homeViewModel.viewEventFlow.collect { viewEvent ->
             when (viewEvent) {
-                is HomeViewModel.ViewEvent.ShowWebView -> encodedUrl = viewEvent.encodedUrl
+                is HomeViewModel.ViewEvent.ShowWebView -> {
+                    val encodedUrl = viewEvent.encodedUrl
+                    if (encodedUrl.isNotBlank()) {
+                        onGoToWebClicked(encodedUrl)
+                    }
+                }
             }
         }
     }
-    if (encodedUrl.isNotBlank()) {
-        onGoToWebClicked(encodedUrl)
-    }
+
 }


### PR DESCRIPTION
### :tophat: What is the goal?

Fix the following scenario:

https://user-images.githubusercontent.com/1390475/208025219-2c9cc611-d7b4-4dad-8dab-921ca1eb6581.mov

Some related logs:

```
2022-12-15 22:50:34.900 15347-15347 chromium                soy.gabimoreno.debug                 E  [ERROR:aw_browser_terminator.cc(156)] Renderer process (15739) crash detected (code -1).
2022-12-15 22:50:34.923 15347-15347 chromium                soy.gabimoreno.debug                 E  [ERROR:aw_browser_terminator.cc(112)] Render process (15739) kill (OOM or update) wasn't handed by all associated webviews, killing application.
```

**How to replicate?**

1. Go to the app's config and verify the domain `gabimoreno.soy` is linked to the app.

<img src="https://user-images.githubusercontent.com/1390475/208025390-f593b3f3-aaae-4ece-a6ad-1dd6e3b17a63.png" width="250" />

2. Open a web link [like this](https://gabimoreno.soy/fernando-franco) using a third party app like gmail (keep in mind app links on android open different apps depending on how the link was pressed), then verify the app is launched but suddenly the WebView Screen starts to blink multiple times until the app crashes.

Tested on:

1. Google Pixel 6, android 13
2. Xioami Redmi Note 8 pro, android 10
5. Android Emulator, android 13

**Why is this happening?**

It seems the state holder `encodedUrl` is triggering infinite recompositions.

**Disclaimer**: It's my first time dealing with Compose on a production app 😅

### Types of changes

- [X] Bug fix

The proposed solution is simple: just remove the state holder because IMO is not necessary.
Perhaps this is not the ideal solution but at least this PR is a way to report the 🐞 and start a discussion with possible solutions 😀

**After the workaround**

https://user-images.githubusercontent.com/1390475/208026321-25d97fb4-6661-4875-af59-cf713a6087ee.mov

