### PR TITLE
Create unit tests for RemotePodcastRepository

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/data/remote/datasource/podcast/PodcastDatasource.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/remote/datasource/podcast/PodcastDatasource.kt
@@ -1,8 +1,9 @@
 package soy.gabimoreno.data.remote.datasource.podcast
 
 import arrow.core.Either
+import soy.gabimoreno.di.data.PodcastUrl
 import soy.gabimoreno.domain.model.podcast.EpisodesWrapper
 
 interface PodcastDatasource {
-    suspend fun getEpisodes(url: String): Either<Throwable, EpisodesWrapper>
+    suspend fun getEpisodes(podcastUrl: PodcastUrl): Either<Throwable, EpisodesWrapper>
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/remote/datasource/podcast/RemotePodcastDatasource.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/remote/datasource/podcast/RemotePodcastDatasource.kt
@@ -3,15 +3,16 @@ package soy.gabimoreno.data.remote.datasource.podcast
 import arrow.core.Either
 import com.prof.rssparser.Parser
 import soy.gabimoreno.data.remote.mapper.toDomain
+import soy.gabimoreno.di.data.PodcastUrl
 import soy.gabimoreno.domain.model.podcast.EpisodesWrapper
 
 class RemotePodcastDatasource(
     private val rssParser: Parser,
 ) : PodcastDatasource {
 
-    override suspend fun getEpisodes(url: String): Either<Throwable, EpisodesWrapper> {
+    override suspend fun getEpisodes(podcastUrl: PodcastUrl): Either<Throwable, EpisodesWrapper> {
         return Either.catch {
-            val channel = rssParser.getChannel(url)
+            val channel = rssParser.getChannel(podcastUrl)
             channel.toDomain()
         }
     }

--- a/gabimoreno/src/main/java/soy/gabimoreno/di/data/DatasourceModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/data/DatasourceModule.kt
@@ -21,6 +21,10 @@ object DatasourceModule {
 
     @Provides
     @Singleton
+    fun providePodcastUrl(): PodcastUrl = PODCAST_URL
+
+    @Provides
+    @Singleton
     fun provideLoginDatasource(
         loginService: LoginService,
     ): LoginDatasource = RemoteLoginDatasource(loginService)
@@ -37,3 +41,7 @@ object DatasourceModule {
         rssParser: Parser,
     ): PodcastDatasource = RemotePodcastDatasource(rssParser)
 }
+
+typealias PodcastUrl = String
+
+private const val PODCAST_URL = "https://anchor.fm/s/74bc02a4/podcast/rss"

--- a/gabimoreno/src/main/java/soy/gabimoreno/di/data/RepositoryModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/data/RepositoryModule.kt
@@ -43,5 +43,9 @@ object RepositoryModule {
     @Singleton
     fun providePodcastRepository(
         podcastDatasource: PodcastDatasource,
-    ): PodcastRepository = RemotePodcastRepository(podcastDatasource)
+        podcastUrl: PodcastUrl,
+    ): PodcastRepository = RemotePodcastRepository(
+        podcastDatasource,
+        podcastUrl
+    )
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/podcast/RemotePodcastRepository.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/podcast/RemotePodcastRepository.kt
@@ -2,17 +2,17 @@ package soy.gabimoreno.domain.repository.podcast
 
 import arrow.core.Either
 import soy.gabimoreno.data.remote.datasource.podcast.PodcastDatasource
+import soy.gabimoreno.di.data.PodcastUrl
 import soy.gabimoreno.domain.model.podcast.EpisodesWrapper
 import javax.inject.Singleton
 
 @Singleton
 class RemotePodcastRepository(
     private val podcastDatasource: PodcastDatasource,
+    private val podcastUrl: PodcastUrl,
 ) : PodcastRepository {
 
     override suspend fun getEpisodes(): Either<Throwable, EpisodesWrapper> {
-        return podcastDatasource.getEpisodes(PODCAST_URL)
+        return podcastDatasource.getEpisodes(podcastUrl)
     }
 }
-
-private const val PODCAST_URL = "https://anchor.fm/s/74bc02a4/podcast/rss"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/repository/podcast/RemotePodcastRepositoryTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/repository/podcast/RemotePodcastRepositoryTest.kt
@@ -1,0 +1,58 @@
+package soy.gabimoreno.domain.repository.podcast
+
+import arrow.core.left
+import arrow.core.right
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Before
+import org.junit.Test
+import soy.gabimoreno.core.testing.coVerifyOnce
+import soy.gabimoreno.data.remote.datasource.podcast.PodcastDatasource
+import soy.gabimoreno.di.data.PodcastUrl
+import soy.gabimoreno.fake.buildEpisodesWrapper
+
+@ExperimentalCoroutinesApi
+class RemotePodcastRepositoryTest {
+
+    private val podcastDatasource: PodcastDatasource = mockk()
+    private val podcastUrl: PodcastUrl = "podcastUrl"
+
+    private lateinit var repository: RemotePodcastRepository
+
+    @Before
+    fun setUp() {
+        repository = RemotePodcastRepository(
+            podcastDatasource,
+            podcastUrl
+        )
+    }
+
+    @Test
+    fun `GIVEN successful response WHEN getEpisodes THEN get the expected result`() = runTest {
+        val episodesWrapper = buildEpisodesWrapper()
+        coEvery { podcastDatasource.getEpisodes(podcastUrl) } returns episodesWrapper.right()
+
+        val result = repository.getEpisodes()
+
+        coVerifyOnce {
+            podcastDatasource.getEpisodes(podcastUrl)
+        }
+        result shouldBeEqualTo episodesWrapper.right()
+    }
+
+    @Test
+    fun `GIVEN failure response WHEN getEpisodes THEN get the expected error`() = runTest {
+        val throwable = Throwable()
+        coEvery { podcastDatasource.getEpisodes(podcastUrl) } returns throwable.left()
+
+        val result = repository.getEpisodes()
+
+        coVerifyOnce {
+            podcastDatasource.getEpisodes(podcastUrl)
+        }
+        result shouldBeEqualTo throwable.left()
+    }
+}

--- a/gabimoreno/src/test/java/soy/gabimoreno/fake/FakeEpisodeWrapper.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/fake/FakeEpisodeWrapper.kt
@@ -1,0 +1,9 @@
+package soy.gabimoreno.fake
+
+import soy.gabimoreno.domain.model.podcast.EpisodesWrapper
+
+fun buildEpisodesWrapper() = EpisodesWrapper(
+    count = 1L,
+    total = 1L,
+    episodes = buildEpisodes()
+)


### PR DESCRIPTION
### :tophat: How was this resolved?

Adding a couple of tests:
- 1 for a successful response
- 1 for a failure one

Also, investing the dependency providing the `podcastUrl` by constructor instead of adding it directly.

Note that I've created a `typealias` to distinguish instead of other possible `String` that will require to be provided.
