### PR TITLE
Improvement: Make audio description selectable on the details screen

### DIFF
--- a/gabimoreno/src/androidTest/java/soy/gabimoreno/presentation/ui/SelectableEmphasisTextTest.kt
+++ b/gabimoreno/src/androidTest/java/soy/gabimoreno/presentation/ui/SelectableEmphasisTextTest.kt
@@ -1,0 +1,29 @@
+package soy.gabimoreno.presentation.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+
+internal class SelectableEmphasisTextTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun checkSelectableEmphasisTextIsDisplayed() {
+        val expectedText = "Hello, World!"
+
+        composeTestRule.setContent {
+            SelectableEmphasisText(
+                text = "Hello, World!"
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(expectedText)
+            .assertExists()
+            .assertIsDisplayed()
+    }
+}

--- a/gabimoreno/src/androidTest/java/soy/gabimoreno/presentation/ui/SelectableEmphasisTextTest.kt
+++ b/gabimoreno/src/androidTest/java/soy/gabimoreno/presentation/ui/SelectableEmphasisTextTest.kt
@@ -17,7 +17,7 @@ internal class SelectableEmphasisTextTest {
 
         composeTestRule.setContent {
             SelectableEmphasisText(
-                text = "Hello, World!"
+                text = expectedText
             )
         }
 

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/detail/DetailScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/detail/DetailScreen.kt
@@ -32,6 +32,7 @@ import soy.gabimoreno.presentation.theme.Spacing
 import soy.gabimoreno.presentation.ui.AudioImage
 import soy.gabimoreno.presentation.ui.BackButton
 import soy.gabimoreno.presentation.ui.EmphasisText
+import soy.gabimoreno.presentation.ui.SelectableEmphasisText
 import soy.gabimoreno.presentation.ui.button.PrimaryButton
 import soy.gabimoreno.util.formatMillisecondsAsDate
 import soy.gabimoreno.util.toDurationMinutes
@@ -155,7 +156,7 @@ fun DetailScreen(
 
                     Spacer(modifier = Modifier.height(Spacing.s16))
 
-                    EmphasisText(
+                    SelectableEmphasisText(
                         text = audio.description.parseFromHtmlFormat()
                     )
                 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/ui/EmphasisText.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/ui/EmphasisText.kt
@@ -1,12 +1,19 @@
 package soy.gabimoreno.presentation.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun EmphasisText(
@@ -20,4 +27,37 @@ fun EmphasisText(
             style = style
         )
     }
+}
+
+@Composable
+fun SelectableEmphasisText(
+    text: String,
+    modifier: Modifier = Modifier,
+    contentAlpha: Float = ContentAlpha.medium,
+    style: TextStyle = MaterialTheme.typography.body1,
+) {
+    SelectionContainer(modifier = modifier) {
+        EmphasisText(
+            text = text,
+            contentAlpha = contentAlpha,
+            style = style
+        )
+    }
+}
+
+@Preview(name = "SelectableEmphasisText with long HTML content")
+@Composable
+private fun SelectableEmphasisTextWithLongContentPreview() {
+    SelectableEmphasisText(
+        text = """
+        <p>Descubre el UNIT TESTING de la mano de Sergio Sastre. Aprende y potencia esta skill para impulsar tu carrera de Android Developer. 🎯</p>
+        <p>
+        👉🏼 NOTAS DEL EPISODIO:</p>
+        <p>https://gabimoreno.soy/unit-testing-topic3-2024</p>
+        """.trimIndent(),
+        modifier = Modifier
+            .background(MaterialTheme.colors.background)
+            .fillMaxSize()
+            .padding(8.dp)
+    )
 }


### PR DESCRIPTION
### 🎩 What is the problem?

Currently, the content/description displayed in the details screen is not selectable, therefore the user can't copy relevant information like links.

### :tophat: How was this resolved?

Implementing `SelectionContainer` and wrapping it by creating a new composable: `SelectableEmphasisText`

<img src="https://github.com/soygabimoreno/Base/assets/1390475/83754b17-7101-4ac4-8140-5ac515580e88" width=300 />