### PR TITLE
Upgrade project dependencies

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 

--- a/bike/build.gradle.kts
+++ b/bike/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.androidApplication)
+    alias(libs.plugins.compose.compiler)
     kotlin("android")
     kotlin("kapt")
     id("dagger.hilt.android.plugin")
@@ -32,11 +33,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_21.toString()
     }
     buildFeatures {
         compose = true
@@ -44,9 +45,9 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
-    packagingOptions {
+    packaging {
         resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            excludes += "/META-INF/{AL2.0,LGPL2.1,LICENSE.md,LICENSE-notice.md}"
         }
     }
 }

--- a/bike/src/main/AndroidManifest.xml
+++ b/bike/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="soy.gabimoreno.bike">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission
         android:name="android.permission.BLUETOOTH"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,13 +10,10 @@ plugins {
     alias(libs.plugins.androidApplication).apply(false)
     alias(libs.plugins.androidLibrary).apply(false)
     alias(libs.plugins.jetbrainsCompose).apply(false)
+    alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.detekt.gradle.plugin)
     alias(libs.plugins.secrets.gradle.plugin) apply false
 }
 
 apply(from = "gradle-scripts/detekt.gradle")
 apply(from = "gradle-scripts/ktlint.gradle.kts")
-
-tasks.register("clean", Delete::class) {
-    delete(rootProject.buildDir)
-}

--- a/gabimoreno/build.gradle.kts
+++ b/gabimoreno/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
-import org.jetbrains.compose.ComposePlugin.CommonComponentsDependencies.resources
 
 plugins {
     alias(libs.plugins.androidApplication)
@@ -11,6 +10,7 @@ plugins {
     id("com.google.firebase.crashlytics")
     alias(libs.plugins.secrets.gradle.plugin)
     alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.compose.compiler)
 }
 
 @Suppress("UnstableApiUsage")
@@ -18,7 +18,7 @@ android {
     if (isLocalBuild()) {
         signingConfigs {
             create("release") {
-                val localProperties = gradleLocalProperties(rootDir)
+                val localProperties = gradleLocalProperties(rootDir, providers)
                 keyAlias = localProperties.getProperty("keystore.keyAlias")
                 storeFile = file(localProperties.getProperty("keystore.storeFile") ?: "fakePath")
                 storePassword = localProperties.getProperty("keystore.storePassword")
@@ -97,22 +97,20 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_21.toString()
     }
     buildFeatures {
         buildConfig = true
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
-    }
+
     packaging {
         resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            excludes += "/META-INF/{AL2.0,LGPL2.1,LICENSE.md,LICENSE-notice.md}"
         }
     }
 }
@@ -137,10 +135,10 @@ dependencies {
     implementation(libs.activity.compose)
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.compose.runtime)
-    implementation(platform("com.google.firebase:firebase-bom:32.1.1"))
-    implementation("com.google.firebase:firebase-analytics-ktx")
-    implementation("com.google.firebase:firebase-crashlytics-ktx")
-    implementation("com.google.firebase:firebase-messaging-ktx")
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.analytics)
+    implementation(libs.firebase.messaging)
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
     implementation(libs.hilt.navigation.compose)

--- a/gabimoreno/src/main/java/soy/gabimoreno/di/AudioModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/AudioModule.kt
@@ -26,7 +26,7 @@ object AudioModule {
     @ServiceScoped
     fun provideAudioAttributes(): AudioAttributes =
         AudioAttributes.Builder()
-            .setContentType(C.CONTENT_TYPE_MUSIC)
+            .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
             .setUsage(C.USAGE_MEDIA)
             .build()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,11 +5,12 @@ kotlin.incremental=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8192m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
-kotlin.version=1.9.20
-agp.version=8.2.0
-compose.version=1.5.11
+kotlin.version=2.1.20
+agp.version=8.6.1
+compose.version=1.7.8
 org.jetbrains.compose.experimental.uikit.enabled=true
+kapt.use.k2=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,53 +1,55 @@
 [versions]
-sdk-compile = "34"
-sdk-target = "34"
+sdk-compile = "35"
+sdk-target = "35"
 sdk-minimum = "23"
-agp = "8.2.0"
-kotlin = "1.9.20"
+agp = "8.6.1"
+kotlin = "2.1.20"
 accompanist-coil = "0.12.0"
 accompanist-insets = "0.12.0"
-androidx-junit = "1.1.5"
-appcompat = "1.6.1"
-arrow-core = "1.0.1"
+androidx-junit = "1.2.1"
+appcompat = "1.7.0"
+arrow-core = "1.2.0"
 clarity = "1.3.0"
 crashlytics = "2.9.7"
-activity-compose = "1.8.1"
-compose-runtime = "1.5.4"
-compose-ui = "1.5.4"
-compose-ui-test-manifest = "1.5.4"
+activity-compose = "1.10.1"
+compose-runtime = "1.7.8"
+compose-ui = "1.7.8"
+compose-ui-test-manifest = "1.7.8"
 compose-compiler = "1.5.5"
-navigation-compose = "2.7.5"
-hilt-navigation-compose = "1.1.0"
+navigation-compose = "2.8.9"
+hilt-navigation-compose = "1.2.0"
 converter-moshi = "2.9.0"
-core-ktx = "1.12.0"
-datastore-preferences = "1.0.0"
-detekt = "1.19.0"
-espresso-core = "3.5.1"
+core-ktx = "1.16.0"
+datastore-preferences = "1.1.4"
+detekt = "1.23.8"
+espresso-core = "3.6.1"
 exoplayer = "2.19.1"
 fastble = "2.4.0"
-glide = "4.12.0"
-google-material = "1.10.0"
-google-services = "4.4.0"
-gson = "2.10.1"
-hilt-android = "2.48.1"
+glide = "4.16.0"
+google-material = "1.12.0"
+google-services = "4.4.2"
+gson = "2.11.0"
+hilt-android = "2.56.1"
 secrets-gradle-plugin = "2.0.1"
 compose-plugin = "1.6.10"
 
+firebaseBom = "33.12.0"
+
 junit = "4.13.2"
 kluent-android = "1.73"
-kotlinx-coroutines-test = "1.7.1"
+kotlinx-coroutines-test = "1.10.1"
 kotest = "5.5.4"
-lifecycle-runtime-ktx = "2.6.2"
-logging-interceptor = "4.9.2"
-material = "1.5.4"
-mockk = "1.12.4"
-mockwebserver = "4.9.3"
+lifecycle-runtime-ktx = "2.8.7"
+logging-interceptor = "4.12.0"
+material = "1.7.8"
+mockk = "1.13.10"
+mockwebserver = "4.12.0"
 moshi = "1.15.0"
 okhttp3-idling-resource = "1.0.0"
 palette = "1.0.0"
 retrofit = "2.9.0"
 robolectric = "4.10.3"
-room-runtime = "2.6.1"
+room-runtime = "2.7.0"
 rssparser = "4.0.2"
 turbine = "0.12.3"
 
@@ -101,6 +103,13 @@ palette = { module = "androidx.palette:palette-ktx", version.ref = "palette" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 rssparser = { module = "com.prof18.rssparser:rssparser", version.ref = "rssparser" }
 
+# Firebase
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
+firebase-config = { module = "com.google.firebase:firebase-config-ktx" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging-ktx" }
+
 # Tests
 junit = { module = "junit:junit", version.ref = "junit" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
@@ -132,3 +141,4 @@ jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 secrets-gradle-plugin = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets-gradle-plugin" }
 detekt-gradle-plugin = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jun 15 17:36:50 BST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/core-testing/build.gradle.kts
+++ b/modules/core-testing/build.gradle.kts
@@ -25,11 +25,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_21.toString()
     }
 }
 

--- a/modules/core-view/build.gradle.kts
+++ b/modules/core-view/build.gradle.kts
@@ -26,11 +26,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_21.toString()
     }
 }
 

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 dependencies {

--- a/modules/framework/build.gradle.kts
+++ b/modules/framework/build.gradle.kts
@@ -26,11 +26,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_21.toString()
     }
 }
 

--- a/modules/player/build.gradle.kts
+++ b/modules/player/build.gradle.kts
@@ -25,11 +25,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_21.toString()
     }
 }
 

--- a/modules/raffle/build.gradle.kts
+++ b/modules/raffle/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 

--- a/modules/remote-config/build.gradle.kts
+++ b/modules/remote-config/build.gradle.kts
@@ -26,11 +26,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.VERSION_21.toString()
     }
 }
 
@@ -40,7 +40,8 @@ dependencies {
     implementation(libs.google.material)
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
-    implementation("com.google.firebase:firebase-config-ktx:21.1.1")
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.config)
 
     testImplementation(libs.junit)
     testImplementation(libs.kluent.android)

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.compose.compiler)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -12,10 +13,10 @@ kotlin {
 
     val isMacOS = System.getProperty("os.name").lowercase(Locale.getDefault()).contains("mac")
 
-    android {
+    androidTarget {
         compilations.all {
             kotlinOptions {
-                jvmTarget = JavaVersion.VERSION_17.toString()
+                jvmTarget = JavaVersion.VERSION_21.toString()
             }
         }
     }
@@ -91,7 +92,7 @@ android {
         minSdk = libs.versions.sdk.minimum.get().toInt()
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 }


### PR DESCRIPTION
Upgrade project to use Gradle 8.11.1, AGP 8.6.1, Kotlin 2.1.20, and Java 21.
- Upgrade dependencies versions.
- Update firebase versions.
- Add compose compiler plugin.
- Update compile and target SDK to 35.
- Exclude additional metadata files from packaging.
