### PR TITLE
refactor: Improve composable key usage and bottom navigation padding

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/navigation/AppBottomNavigation.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/navigation/AppBottomNavigation.kt
@@ -1,6 +1,10 @@
 package soy.gabimoreno.presentation.navigation
 
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material.Icon
@@ -8,7 +12,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun AppBottomNavigation(
@@ -19,7 +22,8 @@ fun AppBottomNavigation(
         NavItem.entries.forEach { item ->
             val title = stringResource(id = item.titleResId)
             BottomNavigationItem(
-                modifier = Modifier.padding(bottom = 8.dp),
+                modifier = Modifier
+                    .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
                 selected = currentRoute.contains(item.navCommand.feature.route),
                 onClick = { onNavItemClick(item) },
                 icon = {

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/courses/detail/AudioCourseDetailScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/courses/detail/AudioCourseDetailScreen.kt
@@ -167,7 +167,10 @@ fun AudioCourseDetailScreen(
                     .border(1.dp, Black.copy(alpha = 0.2f)),
                 verticalArrangement = Arrangement.spacedBy(Spacing.s16),
             ) {
-                items(state.audioCourse.audios.size) { index ->
+                items(
+                    count = state.audioCourse.audios.size,
+                    key = { state.audioCourse.audios[it].id }
+                ) { index ->
                     ItemAudioCourse(
                         audioCourseItem = state.audioCourse.audios[index],
                         audioCourseTitle = state.audioCourse.title,

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/courses/list/AudioCoursesListScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/courses/list/AudioCoursesListScreen.kt
@@ -111,7 +111,10 @@ private fun CoursesListScreenScreen(
                         .padding(horizontal = Spacing.s8),
                     verticalArrangement = Arrangement.spacedBy(Spacing.s16),
                 ) {
-                    items(state.audiocourses.size) { index ->
+                    items(
+                        count = state.audiocourses.size,
+                        key = { state.audiocourses[it].id }
+                    ) { index ->
                         ItemListCourse(
                             audioCourse = state.audiocourses[index],
                             onItemClick = { onAction(AudioCoursesListAction.OnItemClicked(state.audiocourses[index].id)) }


### PR DESCRIPTION
### :tophat: How was this resolved?
This pull request includes two main changes:

1. **Improved Composable Key Usage:** Adds explicit keys for `items` in the `LazyColumn` within `AudioCoursesListScreen` and `AudioCourseDetailScreen`. This helps Jetpack Compose correctly identify items when the list changes, improving performance and avoiding potential issues.

2. **Bottom Navigation Padding Adjustment:** Adjusts the padding of the `BottomNavigationItem` within `AppBottomNavigation` to use `windowInsetsPadding` with `WindowInsets.safeDrawing` and `WindowInsetsSides.Bottom`. This ensures the bottom navigation is correctly positioned relative to system UI elements, providing better adaptation to various screen sizes and layouts.
