### PR TITLE
refactor: Add flag to reload audio courses

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/di/DataStoreModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/DataStoreModule.kt
@@ -8,11 +8,13 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import soy.gabimoreno.domain.session.MemberSession
 import soy.gabimoreno.domain.usecase.GetLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase
+import soy.gabimoreno.domain.usecase.GetShouldIReloadAudioCoursesUseCase
 import soy.gabimoreno.domain.usecase.IsBearerTokenValid
 import soy.gabimoreno.domain.usecase.ResetJwtAuthTokenUseCase
 import soy.gabimoreno.domain.usecase.SaveCredentialsInDataStoreUseCase
 import soy.gabimoreno.domain.usecase.SaveLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase
 import soy.gabimoreno.domain.usecase.SetJwtAuthTokenUseCase
+import soy.gabimoreno.domain.usecase.SetShouldIReloadAudioCoursesUseCase
 import soy.gabimoreno.framework.datastore.DataStoreMemberSession
 import javax.inject.Singleton
 
@@ -61,4 +63,16 @@ object DataStoreModule {
     fun provideGetLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase(
         @ApplicationContext context: Context,
     ) = GetLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase(context)
+
+    @Provides
+    @Singleton
+    fun provideGetShouldIReloadAudioCoursesUseCase(
+        @ApplicationContext context: Context,
+    ) = GetShouldIReloadAudioCoursesUseCase(context)
+
+    @Provides
+    @Singleton
+    fun provideSetShouldIReloadAudioCoursesUseCase(
+        @ApplicationContext context: Context,
+    ) = SetShouldIReloadAudioCoursesUseCase(context)
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetShouldIReloadAudioCoursesUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetShouldIReloadAudioCoursesUseCase.kt
@@ -1,0 +1,14 @@
+package soy.gabimoreno.domain.usecase
+
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+import soy.gabimoreno.framework.datastore.dataStoreShouldIReloadAudiosCourses
+import javax.inject.Inject
+
+class GetShouldIReloadAudioCoursesUseCase @Inject constructor(
+    private val context: Context,
+) {
+    operator fun invoke(): Flow<Boolean> {
+        return context.dataStoreShouldIReloadAudiosCourses()
+    }
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetShouldIReloadAudioCoursesUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetShouldIReloadAudioCoursesUseCase.kt
@@ -1,0 +1,13 @@
+package soy.gabimoreno.domain.usecase
+
+import android.content.Context
+import soy.gabimoreno.framework.datastore.setDataStoreShouldIReloadAudiosCourses
+import javax.inject.Inject
+
+class SetShouldIReloadAudioCoursesUseCase @Inject constructor(
+    private val context: Context,
+) {
+    suspend operator fun invoke(shouldReload: Boolean) {
+        return context.setDataStoreShouldIReloadAudiosCourses(shouldReload)
+    }
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/framework/datastore/DataStoreShouldIReloadAudiosCourses.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/framework/datastore/DataStoreShouldIReloadAudiosCourses.kt
@@ -1,0 +1,24 @@
+package soy.gabimoreno.framework.datastore
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+fun Context.dataStoreShouldIReloadAudiosCourses(): Flow<Boolean> {
+    return dataStore.data
+        .map { preferences ->
+            preferences[key] ?: DEFAULT_FLAG_RELOAD_AUDIOCOURSES
+        }
+}
+
+suspend fun Context.setDataStoreShouldIReloadAudiosCourses(shouldReload: Boolean) {
+    dataStore.edit { settings ->
+        settings[key] = shouldReload
+    }
+}
+
+private const val DEFAULT_FLAG_RELOAD_AUDIOCOURSES = false
+private const val SHOULD_I_RELOAD_AUDIOCOURSES = "SHOULD_I_RELOAD_AUDIOCOURSES"
+private val key = booleanPreferencesKey(SHOULD_I_RELOAD_AUDIOCOURSES)

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/detail/DetailScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/detail/DetailScreen.kt
@@ -55,9 +55,11 @@ fun DetailScreen(
     var audio: Audio? = null
     when (feature) {
         Feature.PODCAST -> {
-            audios =
-                (homeViewModel.viewState as HomeViewModel.ViewState.Success).episodes
-            audio = homeViewModel.findEpisodeFromId(audioId)
+            val viewState = homeViewModel.viewState
+            if (viewState is HomeViewModel.ViewState.Success) {
+                audios = viewState.episodes
+                audio = homeViewModel.findEpisodeFromId(audioId)
+            }
         }
 
         Feature.PREMIUM -> {

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/premium/PremiumViewModel.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/premium/PremiumViewModel.kt
@@ -24,7 +24,9 @@ import soy.gabimoreno.domain.usecase.IsBearerTokenValid
 import soy.gabimoreno.domain.usecase.LoginUseCase
 import soy.gabimoreno.domain.usecase.LoginValidationUseCase
 import soy.gabimoreno.domain.usecase.MarkPremiumAudioAsListenedUseCase
+import soy.gabimoreno.domain.usecase.ResetJwtAuthTokenUseCase
 import soy.gabimoreno.domain.usecase.SaveCredentialsInDataStoreUseCase
+import soy.gabimoreno.domain.usecase.SetShouldIReloadAudioCoursesUseCase
 import javax.inject.Inject
 
 @HiltViewModel
@@ -38,6 +40,8 @@ class PremiumViewModel @Inject constructor(
     private val getPremiumAudioByIdUseCase: GetPremiumAudioByIdUseCase,
     private val isBearerTokenValid: IsBearerTokenValid,
     private val markPremiumAudioAsListenedUseCase: MarkPremiumAudioAsListenedUseCase,
+    private val setShouldIReloadAudioCoursesUseCase: SetShouldIReloadAudioCoursesUseCase,
+    private val resetJwtAuthTokenUseCase: ResetJwtAuthTokenUseCase,
     @IO private val dispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -181,6 +185,7 @@ class PremiumViewModel @Inject constructor(
                                     val isActive = member.isActive || member.status == Status.FREE
                                     memberSession.setActive(isActive)
                                     loginSuccessPerform(email, password)
+                                    setShouldIReloadAudioCoursesUseCase(true)
                                 }
                             )
                     }
@@ -249,6 +254,8 @@ class PremiumViewModel @Inject constructor(
                 shouldShowAccess = true,
                 shouldShowPremium = false
             )
+            resetJwtAuthTokenUseCase()
+            setShouldIReloadAudioCoursesUseCase(true)
         }
     }
 

--- a/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/courses/list/AudioCoursesListViewModelTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/courses/list/AudioCoursesListViewModelTest.kt
@@ -8,6 +8,7 @@ import io.mockk.coEvery
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
@@ -25,20 +26,29 @@ import soy.gabimoreno.core.testing.relaxedMockk
 import soy.gabimoreno.data.remote.model.Category
 import soy.gabimoreno.domain.exception.TokenExpiredException
 import soy.gabimoreno.domain.usecase.GetAudioCoursesUseCase
+import soy.gabimoreno.domain.usecase.GetShouldIReloadAudioCoursesUseCase
+import soy.gabimoreno.domain.usecase.SetShouldIReloadAudioCoursesUseCase
 import soy.gabimoreno.fake.buildAudioCourses
 
 
 class AudioCoursesListViewModelTest {
 
     private val getCoursesUseCase = relaxedMockk<GetAudioCoursesUseCase>()
+    private val getShouldIReloadAudioCoursesUseCase =
+        relaxedMockk<GetShouldIReloadAudioCoursesUseCase>()
+    private val setShouldIReloadAudioCoursesUseCase =
+        relaxedMockk<SetShouldIReloadAudioCoursesUseCase>()
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
     private lateinit var viewModel: AudioCoursesListViewModel
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        coEvery { getShouldIReloadAudioCoursesUseCase() } returns flowOf(false)
         viewModel = AudioCoursesListViewModel(
             getCoursesUseCase,
+            getShouldIReloadAudioCoursesUseCase,
+            setShouldIReloadAudioCoursesUseCase,
             testDispatcher
         )
     }
@@ -56,6 +66,8 @@ class AudioCoursesListViewModelTest {
 
             viewModel = AudioCoursesListViewModel(
                 getCoursesUseCase = getCoursesUseCase,
+                getShouldIReloadAudioCoursesUseCase = getShouldIReloadAudioCoursesUseCase,
+                setShouldIReloadAudioCoursesUseCase = setShouldIReloadAudioCoursesUseCase,
                 dispatcher = testDispatcher
             )
             advanceUntilIdle()
@@ -77,6 +89,8 @@ class AudioCoursesListViewModelTest {
 
         viewModel = AudioCoursesListViewModel(
             getCoursesUseCase,
+            getShouldIReloadAudioCoursesUseCase = getShouldIReloadAudioCoursesUseCase,
+            setShouldIReloadAudioCoursesUseCase = setShouldIReloadAudioCoursesUseCase,
             testDispatcher
         )
         advanceUntilIdle()
@@ -98,6 +112,8 @@ class AudioCoursesListViewModelTest {
 
         viewModel = AudioCoursesListViewModel(
             getCoursesUseCase = getCoursesUseCase,
+            getShouldIReloadAudioCoursesUseCase = getShouldIReloadAudioCoursesUseCase,
+            setShouldIReloadAudioCoursesUseCase = setShouldIReloadAudioCoursesUseCase,
             dispatcher = testDispatcher
         )
         advanceUntilIdle()

--- a/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/premium/PremiumViewModelTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/premium/PremiumViewModelTest.kt
@@ -20,7 +20,9 @@ import soy.gabimoreno.domain.usecase.IsBearerTokenValid
 import soy.gabimoreno.domain.usecase.LoginUseCase
 import soy.gabimoreno.domain.usecase.LoginValidationUseCase
 import soy.gabimoreno.domain.usecase.MarkPremiumAudioAsListenedUseCase
+import soy.gabimoreno.domain.usecase.ResetJwtAuthTokenUseCase
 import soy.gabimoreno.domain.usecase.SaveCredentialsInDataStoreUseCase
+import soy.gabimoreno.domain.usecase.SetShouldIReloadAudioCoursesUseCase
 
 @ExperimentalCoroutinesApi
 class PremiumViewModelTest {
@@ -37,6 +39,9 @@ class PremiumViewModelTest {
     private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
     private val markPremiumAudioAsListenedUseCase =
         relaxedMockk<MarkPremiumAudioAsListenedUseCase>()
+    private val setShouldIReloadAudioCoursesUseCase =
+        relaxedMockk<SetShouldIReloadAudioCoursesUseCase>()
+    private val resetJwtAuthTokenUseCase = relaxedMockk<ResetJwtAuthTokenUseCase>()
     private lateinit var viewModel: PremiumViewModel
 
     @Before
@@ -52,6 +57,8 @@ class PremiumViewModelTest {
             getPremiumAudioByIdUseCase = getPremiumAudioByIdUseCase,
             isBearerTokenValid = isBearerTokenValid,
             markPremiumAudioAsListenedUseCase = markPremiumAudioAsListenedUseCase,
+            setShouldIReloadAudioCoursesUseCase = setShouldIReloadAudioCoursesUseCase,
+            resetJwtAuthTokenUseCase = resetJwtAuthTokenUseCase,
             dispatcher = testDispatcher
         )
     }


### PR DESCRIPTION
### :tophat: How was this resolved?

This commit adds a flag to DataStore that indicates whether the audio courses list should be reloaded. This flag is used by the `AudioCoursesListViewModel` to trigger a refresh of the audio courses when the user logs in or logs out of the premium features.

Changes:
- Add `dataStoreShouldIReloadAudiosCourses` and `setDataStoreShouldIReloadAudiosCourses` extensions to manage the reload flag in DataStore.
- Add `GetShouldIReloadAudioCoursesUseCase` and `SetShouldIReloadAudioCoursesUseCase` to interact with the reload flag in the domain layer.
- Update `AudioCoursesListViewModel` to observe the reload flag and trigger a refresh when it's true.
- Update `PremiumViewModel` to set the reload flag to true upon successful login and logout.
- Add necessary dependencies and update tests.
