### PR TITLE
feat: Show share icon animation after 80% of the audio

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/player/service/MediaPlayerServiceConnection.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/player/service/MediaPlayerServiceConnection.kt
@@ -7,6 +7,9 @@ import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaControllerCompat
 import android.support.v4.media.session.PlaybackStateCompat
 import androidx.compose.runtime.mutableStateOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import soy.gabimoreno.domain.model.audio.Audio
 import soy.gabimoreno.player.exoplayer.AudioMediaSource
 import soy.gabimoreno.player.extension.currentPosition
@@ -38,6 +41,9 @@ class MediaPlayerServiceConnection @Inject constructor(
     ).apply {
         connect()
     }
+
+    private val _progressFlow = MutableStateFlow(0f)
+    val progressFlow: StateFlow<Float> = _progressFlow.asStateFlow()
 
     fun playAudios(audios: List<Audio>) {
         mediaSource.setAudios(audios)
@@ -108,6 +114,9 @@ class MediaPlayerServiceConnection @Inject constructor(
         override fun onPlaybackStateChanged(state: PlaybackStateCompat?) {
             super.onPlaybackStateChanged(state)
             playbackState.value = state
+
+            val progress = state?.extras?.getFloat(PROGRESS_EXTRA, 0f) ?: 0f
+            _progressFlow.value = progress
         }
 
         override fun onMetadataChanged(metadata: MediaMetadataCompat?) {

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/detail/DetailScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/detail/DetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -30,10 +31,12 @@ import soy.gabimoreno.presentation.navigation.Feature
 import soy.gabimoreno.presentation.screen.ViewModelProvider
 import soy.gabimoreno.presentation.screen.home.HomeViewModel
 import soy.gabimoreno.presentation.theme.Spacing
+import soy.gabimoreno.presentation.theme.White
 import soy.gabimoreno.presentation.ui.AudioImage
 import soy.gabimoreno.presentation.ui.BackButton
 import soy.gabimoreno.presentation.ui.EmphasisText
 import soy.gabimoreno.presentation.ui.SelectableEmphasisText
+import soy.gabimoreno.presentation.ui.button.AnimatedIconButton
 import soy.gabimoreno.presentation.ui.button.PrimaryButton
 import soy.gabimoreno.util.formatMillisecondsAsDate
 import soy.gabimoreno.util.toDurationMinutes
@@ -69,7 +72,6 @@ fun DetailScreen(
         }
 
         else -> Unit
-
     }
 
     LaunchedEffect(Unit) {
@@ -136,7 +138,9 @@ fun DetailScreen(
 
                     Spacer(modifier = Modifier.height(Spacing.s16))
 
-                    Row {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
                         PrimaryButton(
                             text = playButtonText,
                             height = Spacing.s48
@@ -149,9 +153,13 @@ fun DetailScreen(
 
                         Spacer(modifier = Modifier.weight(1f))
 
-                        soy.gabimoreno.presentation.ui.IconButton(
+                        AnimatedIconButton(
+                            showAnimation = (
+                                playerViewModel.currentPlayingAudio.value?.id == audio.id &&
+                                    playerViewModel.hasTriggeredEightyPercent),
                             imageVector = Icons.Default.Share,
                             contentDescription = stringResource(R.string.share),
+                            tint = White,
                             padding = Spacing.s16
                         ) {
                             detailViewModel.onShareClicked(currentContext, audio)

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/ui/button/AnimatedIconButton.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/ui/button/AnimatedIconButton.kt
@@ -1,0 +1,155 @@
+package soy.gabimoreno.presentation.ui.button
+
+import androidx.compose.animation.animateColor
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateValue
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import soy.gabimoreno.presentation.theme.GabiMorenoTheme
+import soy.gabimoreno.presentation.theme.Orange
+import soy.gabimoreno.presentation.theme.Spacing
+import soy.gabimoreno.presentation.ui.IconButton
+
+@Composable
+fun AnimatedIconButton(
+    showAnimation: Boolean,
+    imageVector: ImageVector,
+    contentDescription: String,
+    padding: Dp,
+    modifier: Modifier = Modifier,
+    tint: Color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
+    transitionTint: Color = Orange,
+    onClick: () -> Unit,
+) {
+    val baseSize = 32.dp
+    val infiniteTransition = rememberInfiniteTransition(label = "${contentDescription}Pulse")
+
+    val animatedScale by infiniteTransition.animateFloat(
+        initialValue = 1.1f,
+        targetValue = if (showAnimation) 1.4f else 1.1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = ANIMATION_DURATION,
+                easing = FastOutSlowInEasing
+            ),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "scaleAnim"
+    )
+
+    val animatedAlpha by infiniteTransition.animateFloat(
+        initialValue = 0.05f,
+        targetValue = if (showAnimation) 1f else 0.05f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = ANIMATION_DURATION_COLOR_CIRCLE,
+                easing = FastOutSlowInEasing
+            ),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "circleAlpha"
+    )
+
+    val animatedSize by infiniteTransition.animateValue(
+        initialValue = baseSize * 1.1f,
+        targetValue = if (showAnimation) baseSize * 1.5f else baseSize * 1.1f,
+        typeConverter = Dp.VectorConverter,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = ANIMATION_DURATION,
+                easing = FastOutLinearInEasing
+            ),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "pulsingSize"
+    )
+
+    val animatedTint by infiniteTransition.animateColor(
+        initialValue = tint,
+        targetValue = if (showAnimation) transitionTint else tint,
+        animationSpec = infiniteRepeatable(
+            animation = tween(ANIMATION_DURATION),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "tint"
+    )
+
+    val animatedCircleColor by infiniteTransition.animateColor(
+        initialValue = tint,
+        targetValue = if (showAnimation) transitionTint else tint,
+        animationSpec = infiniteRepeatable(
+            animation = tween(ANIMATION_DURATION_COLOR_CIRCLE),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "circleColor"
+    )
+
+    Box(contentAlignment = Alignment.Center) {
+        Box(
+            modifier = modifier
+                .size(animatedSize)
+                .clip(CircleShape)
+                .border(
+                    width = 2.dp,
+                    color = animatedCircleColor.copy(alpha = animatedAlpha),
+                    shape = CircleShape
+                )
+        )
+        IconButton(
+            imageVector = imageVector,
+            contentDescription = contentDescription,
+            padding = padding,
+            modifier = modifier
+                .padding(end = Spacing.s4)
+                .graphicsLayer {
+                    scaleX = animatedScale
+                    scaleY = animatedScale
+                },
+            tint = animatedTint,
+            onClick = onClick
+        )
+    }
+}
+
+private const val ANIMATION_DURATION = 900
+private const val ANIMATION_DURATION_COLOR_CIRCLE = 700
+
+@Preview
+@Composable
+private fun AnimatedIconButtonPreview() {
+    GabiMorenoTheme {
+
+        AnimatedIconButton(
+            showAnimation = true,
+            imageVector = Icons.Default.Share,
+            contentDescription = "Share",
+            padding = Spacing.s16,
+            onClick = {}
+        )
+    }
+}


### PR DESCRIPTION
### :tophat: How was this resolved?

The share icon in the audio detail screen now animates after the user has listened to 80% of the audio. This is achieved by:

- Exposing a `progressFlow` from `MediaPlayerServiceConnection` to observe audio progress.
- Updating the playback state in `MediaPlayerService` with the current progress.
- Introducing an `AnimatedIconButton` composable that handles the animation logic.
- Triggering the animation in `DetailScreen` based on the `hasTriggeredEightyPercent` flag from `PlayerViewModel`.
- Logic to mark audio as listened is now based on `progressFlow` instead of `PLAYBACK_POSITION_UPDATE_INTERVAL`.
