### PR TITLE
feat: Reverse Podcast Order

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/di/DataStoreModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/DataStoreModule.kt
@@ -8,12 +8,14 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import soy.gabimoreno.domain.session.MemberSession
 import soy.gabimoreno.domain.usecase.GetLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase
+import soy.gabimoreno.domain.usecase.GetShouldIReversePodcastOrderUseCase
 import soy.gabimoreno.domain.usecase.GetShouldIReloadAudioCoursesUseCase
 import soy.gabimoreno.domain.usecase.IsBearerTokenValid
 import soy.gabimoreno.domain.usecase.ResetJwtAuthTokenUseCase
 import soy.gabimoreno.domain.usecase.SaveCredentialsInDataStoreUseCase
 import soy.gabimoreno.domain.usecase.SaveLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase
 import soy.gabimoreno.domain.usecase.SetJwtAuthTokenUseCase
+import soy.gabimoreno.domain.usecase.SetShouldIReversePodcastOrderUseCase
 import soy.gabimoreno.domain.usecase.SetShouldIReloadAudioCoursesUseCase
 import soy.gabimoreno.framework.datastore.DataStoreMemberSession
 import javax.inject.Singleton
@@ -75,4 +77,16 @@ object DataStoreModule {
     fun provideSetShouldIReloadAudioCoursesUseCase(
         @ApplicationContext context: Context,
     ) = SetShouldIReloadAudioCoursesUseCase(context)
+
+    @Provides
+    @Singleton
+    fun provideGetShouldIInvestPodcastOrderUseCase(
+        @ApplicationContext context: Context,
+    ) = GetShouldIReversePodcastOrderUseCase(context)
+
+    @Provides
+    @Singleton
+    fun provideSetShouldIInvestPodcastOrderUseCase(
+        @ApplicationContext context: Context,
+    ) = SetShouldIReversePodcastOrderUseCase(context)
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetShouldIReversePodcastOrderUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetShouldIReversePodcastOrderUseCase.kt
@@ -1,0 +1,15 @@
+package soy.gabimoreno.domain.usecase
+
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import soy.gabimoreno.framework.datastore.dataStoreShouldIReversePodcastOrder
+import javax.inject.Inject
+
+class GetShouldIReversePodcastOrderUseCase @Inject constructor(
+    private val context: Context,
+) {
+    suspend operator fun invoke(): Boolean {
+        return context.dataStoreShouldIReversePodcastOrder().first()
+    }
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetShouldIReversePodcastOrderUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetShouldIReversePodcastOrderUseCase.kt
@@ -1,0 +1,13 @@
+package soy.gabimoreno.domain.usecase
+
+import android.content.Context
+import soy.gabimoreno.framework.datastore.setDataStoreShouldIReversePodcastOrder
+import javax.inject.Inject
+
+class SetShouldIReversePodcastOrderUseCase @Inject constructor(
+    private val context: Context,
+) {
+    suspend operator fun invoke(reversePodcastOrder: Boolean) {
+        return context.setDataStoreShouldIReversePodcastOrder(reversePodcastOrder)
+    }
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/framework/datastore/DataStoreShouldIInvestPodcastOrder.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/framework/datastore/DataStoreShouldIInvestPodcastOrder.kt
@@ -1,0 +1,24 @@
+package soy.gabimoreno.framework.datastore
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+fun Context.dataStoreShouldIReversePodcastOrder(): Flow<Boolean> {
+    return dataStore.data
+        .map { preferences ->
+            preferences[key] ?: DEFAULT_FLAG_REVERSE_PODCAST_ORDER
+        }
+}
+
+suspend fun Context.setDataStoreShouldIReversePodcastOrder(shouldReverse: Boolean) {
+    dataStore.edit { settings ->
+        settings[key] = shouldReverse
+    }
+}
+
+private const val DEFAULT_FLAG_REVERSE_PODCAST_ORDER = false
+private const val SHOULD_I_REVERSE_PODCAST_ORDER = "SHOULD_I_REVERSE_PODCAST_ORDER"
+private val key = booleanPreferencesKey(SHOULD_I_REVERSE_PODCAST_ORDER)

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/auth/AuthViewModel.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/auth/AuthViewModel.kt
@@ -20,6 +20,7 @@ import soy.gabimoreno.domain.session.MemberSession
 import soy.gabimoreno.domain.usecase.IsBearerTokenValid
 import soy.gabimoreno.domain.usecase.LoginUseCase
 import soy.gabimoreno.domain.usecase.LoginValidationUseCase
+import soy.gabimoreno.domain.usecase.RefreshAudioCoursesUseCase
 import soy.gabimoreno.domain.usecase.ResetJwtAuthTokenUseCase
 import soy.gabimoreno.domain.usecase.SaveCredentialsInDataStoreUseCase
 import soy.gabimoreno.domain.usecase.SetShouldIReloadAudioCoursesUseCase
@@ -35,6 +36,7 @@ class AuthViewModel @Inject constructor(
     private val isBearerTokenValid: IsBearerTokenValid,
     private val setShouldIReloadAudioCoursesUseCase: SetShouldIReloadAudioCoursesUseCase,
     private val resetJwtAuthTokenUseCase: ResetJwtAuthTokenUseCase,
+    private val refreshAudioCoursesUseCase: RefreshAudioCoursesUseCase,
     @IO private val dispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -192,6 +194,7 @@ class AuthViewModel @Inject constructor(
             memberSession.setActive(false)
             memberSession.setEmail(email = null)
             resetJwtAuthTokenUseCase()
+            refreshAudioCoursesUseCase()
             state = state.copy(
                 isLoading = false,
                 shouldShowAccess = true,

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/home/HomeScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/home/HomeScreen.kt
@@ -1,22 +1,32 @@
 package soy.gabimoreno.presentation.screen.home
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -24,12 +34,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 import com.google.accompanist.insets.navigationBarsPadding
-import com.google.accompanist.insets.statusBarsPadding
 import soy.gabimoreno.R
 import soy.gabimoreno.core.normalizeText
 import soy.gabimoreno.presentation.navigation.deeplink.DeepLinkEpisodeNumber
@@ -50,12 +61,10 @@ fun HomeScreen(
     val scrollState = rememberLazyListState()
     val homeViewModel = ViewModelProvider.homeViewModel
     val viewState = homeViewModel.viewState
-
+    var searchTextState by remember { mutableStateOf(TextFieldValue("")) }
     LaunchedEffect(Unit) {
         homeViewModel.onViewScreen()
     }
-
-    var searchTextState by remember { mutableStateOf(TextFieldValue("")) }
 
     Surface {
         Column {
@@ -64,22 +73,57 @@ fun HomeScreen(
                     .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Top))
                     .padding(start = Spacing.s16, bottom = Spacing.s4)
             )
-            OutlinedTextField(
-                value = searchTextState,
-                onValueChange = { value ->
-                    searchTextState = value
-                },
-                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Default.Search,
-                        contentDescription = stringResource(id = R.string.search)
-                    )
-                },
-                modifier = Modifier
-                    .padding(start = Spacing.s16, bottom = Spacing.s16, end = Spacing.s16)
-                    .fillMaxWidth()
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OutlinedTextField(
+                    value = searchTextState,
+                    onValueChange = { value ->
+                        searchTextState = value
+                    },
+                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = stringResource(id = R.string.search)
+                        )
+                    },
+                    modifier = Modifier
+                        .padding(start = Spacing.s16, bottom = Spacing.s16, end = Spacing.s16)
+                        .weight(0.95f)
+                )
+                IconButton(
+                    onClick = { homeViewModel.toggleShouldIReversePodcastOrder() },
+                    modifier = Modifier
+                        .padding(bottom = Spacing.s16, end = Spacing.s16)
+                ) {
+                    AnimatedContent(
+                        targetState = homeViewModel.shouldIReversePodcastOrder,
+                        transitionSpec = {
+                            scaleIn(tween(300)) togetherWith scaleOut(tween(500))
+                        },
+                        label = "IconTransition"
+                    ) { reversed ->
+                        if (reversed) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.Sort,
+                                contentDescription = stringResource(R.string.podcast_sort_desc),
+                                modifier = Modifier
+                                    .rotate(180f)
+                                    .size(Spacing.s48)
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.Sort,
+                                contentDescription = stringResource(R.string.podcast_sort_asc),
+                                modifier = Modifier.size(Spacing.s48)
+                            )
+                        }
+                    }
+                }
+            }
             LazyColumn(state = scrollState) {
                 when (viewState) {
                     is HomeViewModel.ViewState.Error -> {

--- a/gabimoreno/src/main/res/values/strings.xml
+++ b/gabimoreno/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="share_podcast_content">Escucha esto️: %1$s %2$s</string>
     <string name="try_again">Prueba de nuevo</string>
     <string name="podcast_thumbnail">Carátula del episodio</string>
+    <string name="podcast_sort_desc">Mostrar podcast en orden descendente</string>
+    <string name="podcast_sort_asc">Mostrar podcast en orden ascendente </string>
     <string name="back">Atrás</string>
     <string name="pause">Pause</string>
     <string name="play">Play</string>

--- a/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/auth/AuthViewModelTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/auth/AuthViewModelTest.kt
@@ -19,6 +19,7 @@ import soy.gabimoreno.domain.session.MemberSession
 import soy.gabimoreno.domain.usecase.IsBearerTokenValid
 import soy.gabimoreno.domain.usecase.LoginUseCase
 import soy.gabimoreno.domain.usecase.LoginValidationUseCase
+import soy.gabimoreno.domain.usecase.RefreshAudioCoursesUseCase
 import soy.gabimoreno.domain.usecase.ResetJwtAuthTokenUseCase
 import soy.gabimoreno.domain.usecase.SaveCredentialsInDataStoreUseCase
 import soy.gabimoreno.domain.usecase.SetShouldIReloadAudioCoursesUseCase
@@ -34,6 +35,7 @@ class AuthViewModelTest {
     private val loginUseCase: LoginUseCase = relaxedMockk()
     private val isBearerTokenValid: IsBearerTokenValid = relaxedMockk()
     private val resetJwtAuthTokenUseCase = relaxedMockk<ResetJwtAuthTokenUseCase>()
+    private val refreshAudioCoursesUseCase = relaxedMockk<RefreshAudioCoursesUseCase>()
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
     private val setShouldIReloadAudioCoursesUseCase =
         relaxedMockk<SetShouldIReloadAudioCoursesUseCase>()
@@ -51,6 +53,7 @@ class AuthViewModelTest {
             isBearerTokenValid = isBearerTokenValid,
             setShouldIReloadAudioCoursesUseCase = setShouldIReloadAudioCoursesUseCase,
             resetJwtAuthTokenUseCase = resetJwtAuthTokenUseCase,
+            refreshAudioCoursesUseCase = refreshAudioCoursesUseCase,
             dispatcher = testDispatcher
         )
     }

--- a/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/home/HomeViewModelTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/home/HomeViewModelTest.kt
@@ -25,6 +25,8 @@ import soy.gabimoreno.data.tracker.main.HomeTrackerEvent
 import soy.gabimoreno.domain.repository.podcast.PodcastRepository
 import soy.gabimoreno.domain.usecase.EncodeUrlUseCase
 import soy.gabimoreno.domain.usecase.GetAppVersionNameUseCase
+import soy.gabimoreno.domain.usecase.GetShouldIReversePodcastOrderUseCase
+import soy.gabimoreno.domain.usecase.SetShouldIReversePodcastOrderUseCase
 
 @ExperimentalCoroutinesApi
 class HomeViewModelTest {
@@ -33,6 +35,8 @@ class HomeViewModelTest {
     private val tracker: Tracker = relaxedMockk()
     private val getAppVersionNameUseCase: GetAppVersionNameUseCase = relaxedMockk()
     private val encodeUrlUseCase: EncodeUrlUseCase = relaxedMockk()
+    private val getShouldIReversePodcastOrderUseCase: GetShouldIReversePodcastOrderUseCase = relaxedMockk()
+    private val setShouldIReversePodcastOrderUseCase: SetShouldIReversePodcastOrderUseCase = relaxedMockk()
     private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
     private lateinit var viewModel: HomeViewModel
 
@@ -44,6 +48,8 @@ class HomeViewModelTest {
             tracker,
             getAppVersionNameUseCase,
             encodeUrlUseCase,
+            getShouldIReversePodcastOrderUseCase,
+            setShouldIReversePodcastOrderUseCase,
             testDispatcher
         )
     }


### PR DESCRIPTION
### :tophat: How was this resolved?

This commit introduces a new feature that allows users to reverse the order of podcasts.

The main changes include:

- Added a new `GetShouldIReversePodcastOrderUseCase` and `SetShouldIReversePodcastOrderUseCase` to get and set the reverse order preference.
- Updated `HomeViewModel` to use the new use cases and toggle the reverse order.
- Updated `HomeScreen` to display a new icon button to toggle the reverse order.
- Added new strings for the reverse order feature.
- Updated `AuthViewModel` to refresh audio courses after logging out.
- Updated `AudioCoursesListViewModel` to handle token expired exceptions more gracefully.
