### PR TITLE
feature: Refresh Bearer Token

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/di/RefreshTokenModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/RefreshTokenModule.kt
@@ -1,0 +1,32 @@
+package soy.gabimoreno.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import soy.gabimoreno.data.remote.datasource.login.LoginDatasource
+import soy.gabimoreno.domain.usecase.RefreshBearerTokenUseCase
+import soy.gabimoreno.domain.usecase.ResetJwtAuthTokenUseCase
+import soy.gabimoreno.domain.usecase.SetJwtAuthTokenUseCase
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class RefreshTokenModule {
+
+    @Provides
+    @Singleton
+    fun provideRefreshBearerTokenUseCase(
+        loginDatasource: LoginDatasource,
+        setJwtAuthTokenUseCase: SetJwtAuthTokenUseCase,
+        resetJwtAuthTokenUseCase: ResetJwtAuthTokenUseCase,
+        @ApplicationContext context: Context,
+    ) = RefreshBearerTokenUseCase(
+        loginDatasource,
+        setJwtAuthTokenUseCase,
+        resetJwtAuthTokenUseCase,
+        context
+    )
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/RefreshBearerTokenUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/RefreshBearerTokenUseCase.kt
@@ -1,0 +1,38 @@
+package soy.gabimoreno.domain.usecase
+
+import android.content.Context
+import arrow.core.Either
+import arrow.core.left
+import kotlinx.coroutines.flow.first
+import soy.gabimoreno.data.remote.datasource.login.LoginDatasource
+import soy.gabimoreno.domain.exception.TokenExpiredException
+import soy.gabimoreno.framework.datastore.getEmail
+import soy.gabimoreno.framework.datastore.getPassword
+import javax.inject.Inject
+
+class RefreshBearerTokenUseCase @Inject constructor(
+    private val loginDatasource: LoginDatasource,
+    private val setJwtAuthTokenUseCase: SetJwtAuthTokenUseCase,
+    private val resetJwtAuthTokenUseCase: ResetJwtAuthTokenUseCase,
+    private val context: Context,
+) {
+    suspend operator fun invoke(): Either<Throwable, Unit> {
+        val email = context.getEmail().first()
+        val password = context.getPassword().first()
+        if (email.isEmpty() || password.isEmpty()) {
+            return expireToken()
+        }
+        return loginDatasource.obtainToken(email, password)
+            .map { jwtAuth ->
+                val token = jwtAuth.token
+                setJwtAuthTokenUseCase(token)
+            }.map {
+                expireToken()
+            }
+    }
+
+    private suspend fun expireToken(): Either<TokenExpiredException, Nothing> {
+        resetJwtAuthTokenUseCase()
+        return TokenExpiredException().left()
+    }
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/courses/list/AudioCoursesListState.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/courses/list/AudioCoursesListState.kt
@@ -6,4 +6,5 @@ data class AudioCoursesListState(
     val isLoading: Boolean = true,
     val isRefreshing: Boolean = false,
     val audiocourses: List<AudioCourse> = emptyList(),
+    val hasRefreshTokenBeenCalled: Boolean = false,
 )

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/premium/PremiumState.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/premium/PremiumState.kt
@@ -7,12 +7,11 @@ import soy.gabimoreno.domain.model.content.PremiumAudio
 
 data class PremiumState(
     val isLoading: Boolean = true,
-
     val selectedPremiumAudio: PremiumAudio? = null,
     val premiumAudioFlow: Flow<PagingData<PremiumAudio>> = flow { PagingData.empty<PremiumAudio>() },
     val premiumAudios: List<PremiumAudio> = EMPTY_PREMIUM_AUDIOS,
-
     val shouldIAccessPremium: Boolean = false,
+    val hasRefreshTokenBeenCalled: Boolean = false,
 )
 
 val EMPTY_PREMIUM_AUDIOS = emptyList<PremiumAudio>()

--- a/gabimoreno/src/test/java/soy/gabimoreno/data/remote/datasource/audiocourses/RemoteAudioCoursesDataSourceTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/data/remote/datasource/audiocourses/RemoteAudioCoursesDataSourceTest.kt
@@ -7,11 +7,11 @@ import org.amshove.kluent.shouldBe
 import org.junit.Before
 import org.junit.Test
 import soy.gabimoreno.core.testing.coVerifyOnce
-import soy.gabimoreno.data.remote.service.PostService
+import soy.gabimoreno.core.testing.relaxedMockk
 import soy.gabimoreno.data.remote.model.Category
 import soy.gabimoreno.data.remote.model.course.CourseApiModel
 import soy.gabimoreno.data.remote.model.toQueryValue
-import soy.gabimoreno.core.testing.relaxedMockk
+import soy.gabimoreno.data.remote.service.PostService
 
 
 class RemoteAudioCoursesDataSourceTest {

--- a/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/premium/PremiumViewModelTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/premium/PremiumViewModelTest.kt
@@ -16,6 +16,7 @@ import soy.gabimoreno.core.testing.relaxedMockk
 import soy.gabimoreno.domain.usecase.GetPremiumAudioByIdUseCase
 import soy.gabimoreno.domain.usecase.GetPremiumAudiosManagedUseCase
 import soy.gabimoreno.domain.usecase.MarkPremiumAudioAsListenedUseCase
+import soy.gabimoreno.domain.usecase.RefreshBearerTokenUseCase
 
 @ExperimentalCoroutinesApi
 class PremiumViewModelTest {
@@ -24,6 +25,7 @@ class PremiumViewModelTest {
     private val getPremiumAudioByIdUseCase = relaxedMockk<GetPremiumAudioByIdUseCase>()
     private val markPremiumAudioAsListenedUseCase =
         relaxedMockk<MarkPremiumAudioAsListenedUseCase>()
+    private val refreshBearerTokenUseCase = relaxedMockk<RefreshBearerTokenUseCase>()
     private val testDispatcher = UnconfinedTestDispatcher()
 
     @Before
@@ -44,6 +46,7 @@ class PremiumViewModelTest {
                 getPremiumAudiosMediatorUseCase,
                 getPremiumAudioByIdUseCase,
                 markPremiumAudioAsListenedUseCase,
+                refreshBearerTokenUseCase,
                 testDispatcher
             )
 
@@ -61,6 +64,7 @@ class PremiumViewModelTest {
                 getPremiumAudiosMediatorUseCase,
                 getPremiumAudioByIdUseCase,
                 markPremiumAudioAsListenedUseCase,
+                refreshBearerTokenUseCase,
                 testDispatcher
             )
 


### PR DESCRIPTION
### :tophat: How was this resolved?

Now we try to refresh the bearer token into the `AudioCoursesListViewModel` and `PremiumViewModel` when an API call returns a token expired error (or HTTP 403) once.
