### PR TITLE
Update README with Gradle build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Base
 This is the base of the multi-module repo.
 
+## Prerequisites
+
+- **JDK 21**. Make sure `java --version` reports a JDK 21 installation.
+- **Android SDK 35** or newer installed via Android Studio or the
+  command line tools.
+
+Update your `local.properties` with your keys and any other secrets as
+described below so the project can be built and signed.
+
 ## App Los androides by Gabi Moreno
 This is the module corresponding to the app Los androides by Gabi Moreno.
 
@@ -44,5 +53,36 @@ keystore.storeFile=foo
 keystore.storePassword=foo
 keystore.keyPassword=foo
 ```
+
+## Building with Gradle
+
+From the repository root run:
+
+```bash
+./gradlew assembleDebug
+```
+
+This compiles all modules. You can build a specific sample app by
+providing its Gradle path, for example `:gabimoreno` or `:bike`.
+
+### Running sample apps
+
+Deploy the debug build of a module to a connected device or emulator:
+
+```bash
+./gradlew :gabimoreno:installDebug   # Los androides
+./gradlew :bike:installDebug         # Bike demo
+```
+
+### Running unit tests
+
+Execute all unit tests across the project with:
+
+```bash
+./gradlew test
+```
+
+You can run tests for a single module using its path, e.g.
+`./gradlew :modules:core:test`.
 
 Thank you very much for being part of this project! 🤗


### PR DESCRIPTION
## Summary
- document JDK and Android SDK requirements
- explain how to build modules with Gradle
- add commands for running unit tests and installing sample apps

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684026ba29b88321b918661458a53dbd