### PR TITLE
feat: Add PlaylistCategory to Playlist

### DIFF
--- a/gabimoreno/schemas/soy.gabimoreno.data.local.GabiMorenoDatabase/5.json
+++ b/gabimoreno/schemas/soy.gabimoreno.data.local.GabiMorenoDatabase/5.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 5,
-    "identityHash": "d84838988c446dc26dd90730522a34cc",
+    "identityHash": "35e32d25b11e99ee60d6acc3946ffa0d",
     "entities": [
       {
         "tableName": "PremiumAudioDbModel",
@@ -246,7 +246,7 @@
       },
       {
         "tableName": "PlaylistDbModel",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `position` INTEGER NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `categoryId` INTEGER NOT NULL, `description` TEXT NOT NULL, `position` INTEGER NOT NULL, `title` TEXT NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
@@ -254,9 +254,9 @@
             "affinity": "INTEGER"
           },
           {
-            "fieldPath": "title",
-            "columnName": "title",
-            "affinity": "TEXT",
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
             "notNull": true
           },
           {
@@ -269,6 +269,12 @@
             "fieldPath": "position",
             "columnName": "position",
             "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
             "notNull": true
           }
         ],
@@ -341,7 +347,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd84838988c446dc26dd90730522a34cc')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '35e32d25b11e99ee60d6acc3946ffa0d')"
     ]
   }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/local/mapper/ToPlaylistDbMapper.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/local/mapper/ToPlaylistDbMapper.kt
@@ -8,9 +8,10 @@ import soy.gabimoreno.domain.model.content.PlaylistAudioItem
 
 fun Playlist.toPlaylistDbModel() = PlaylistDbModel(
     id = id,
-    title = title,
+    categoryId = category.id,
     description = description,
     position = position,
+    title = title,
 )
 
 fun PlaylistAudioItem.toPlaylistItemDbModel(playlistId: Int) = PlaylistItemsDbModel(

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/local/mapper/ToPlaylistMapper.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/local/mapper/ToPlaylistMapper.kt
@@ -3,11 +3,13 @@ package soy.gabimoreno.data.local.mapper
 import soy.gabimoreno.data.local.playlist.model.PlaylistDbModel
 import soy.gabimoreno.domain.model.content.Playlist
 import soy.gabimoreno.domain.model.content.PlaylistAudioItem
+import soy.gabimoreno.domain.model.content.getPlaylistCategoryFromId
 
 fun PlaylistDbModel.toPlaylistMapper(playlistWithItems: List<PlaylistAudioItem>) = Playlist(
     id = requireNotNull(id) { "PlaylistDbModel.id was null when mapping to domain" },
-    title = title,
+    category = getPlaylistCategoryFromId(categoryId),
     description = description,
     position = position,
+    title = title,
     items = playlistWithItems,
 )

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/local/playlist/model/PlaylistDbModel.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/local/playlist/model/PlaylistDbModel.kt
@@ -2,12 +2,14 @@ package soy.gabimoreno.data.local.playlist.model
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import soy.gabimoreno.domain.model.content.PlaylistCategory
 
 @Entity
 data class PlaylistDbModel(
     @PrimaryKey(autoGenerate = true)
     val id: Int? = null,
-    val title: String,
+    val categoryId: Int = PlaylistCategory.USER_PLAYLIST.id,
     val description: String,
     val position: Int,
+    val title: String,
 )

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/model/content/Playlist.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/model/content/Playlist.kt
@@ -2,8 +2,9 @@ package soy.gabimoreno.domain.model.content
 
 data class Playlist(
     val id: Int,
-    val title: String,
+    val category: PlaylistCategory = PlaylistCategory.USER_PLAYLIST,
     val description: String,
-    val position: Int,
     val items: List<PlaylistAudioItem>,
+    val position: Int,
+    val title: String,
 )

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/model/content/PlaylistCategory.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/model/content/PlaylistCategory.kt
@@ -1,0 +1,27 @@
+package soy.gabimoreno.domain.model.content
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LibraryMusic
+import androidx.compose.material.icons.filled.School
+import androidx.compose.ui.graphics.vector.ImageVector
+import soy.gabimoreno.presentation.theme.Orange
+import soy.gabimoreno.presentation.theme.PurpleDark
+
+enum class PlaylistCategory(
+    val id: Int,
+    val color: androidx.compose.ui.graphics.Color,
+    val icon: ImageVector,
+) {
+    USER_PLAYLIST(
+        id = 1,
+        color = Orange,
+        icon = Icons.Default.LibraryMusic,
+    ),
+    ROADMAP_PLAYLIST(
+        id = 2,
+        color = PurpleDark,
+        icon = Icons.Default.School,
+    ),
+}
+
+fun getPlaylistCategoryFromId(id: Int) = PlaylistCategory.entries.first { it.id == id }

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/view/PlaylistItem.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/view/PlaylistItem.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.LibraryMusic
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -33,9 +32,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import soy.gabimoreno.R
 import soy.gabimoreno.domain.model.content.Playlist
+import soy.gabimoreno.domain.model.content.PlaylistCategory
 import soy.gabimoreno.presentation.theme.Black
 import soy.gabimoreno.presentation.theme.GabiMorenoTheme
-import soy.gabimoreno.presentation.theme.Orange
 import soy.gabimoreno.presentation.theme.PurpleLight
 import soy.gabimoreno.presentation.theme.Spacing
 import soy.gabimoreno.presentation.theme.White
@@ -49,9 +48,8 @@ fun PlaylistItem(
     onItemClick: (String) -> Unit = {},
     onToggleClick: (playlistId: Int) -> Unit = {}
 ) {
-    val itemDefaultColor = if ((playlist.position % 2) == 1) Orange else PurpleLight
     val iconColor by animateColorAsState(
-        targetValue = if (isPlaylistSelected) itemDefaultColor else Black.copy(alpha = 0.2f),
+        targetValue = if (isPlaylistSelected) PurpleLight else Black.copy(alpha = 0.2f),
         animationSpec = tween(durationMillis = CHANGE_COLOR_ANIMATION_DURATION),
         label = "selectedPlaylistIconColorAnimation"
     )
@@ -65,10 +63,10 @@ fun PlaylistItem(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Icon(
-            imageVector = Icons.Default.LibraryMusic,
+            imageVector = playlist.category.icon,
             contentDescription = "Playlist",
             modifier = Modifier.size(Spacing.s64),
-            tint = itemDefaultColor
+            tint = playlist.category.color
         )
         Spacer(modifier = Modifier.width(Spacing.s16))
         Column(
@@ -84,7 +82,7 @@ fun PlaylistItem(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(Spacing.s4)
-                    .background(itemDefaultColor)
+                    .background(playlist.category.color)
             )
             Text(
                 playlist.description,
@@ -97,7 +95,11 @@ fun PlaylistItem(
             Box(
                 modifier = Modifier
                     .size(Spacing.s32)
-                    .border(1.dp, itemDefaultColor, shape = CircleShape)
+                    .border(
+                        1.dp,
+                        playlist.category.color,
+                        shape = CircleShape,
+                    )
                     .padding(Spacing.s4),
             ) {
                 IconButton(
@@ -151,9 +153,10 @@ private fun PlaylistItemPreview() {
             PlaylistItem(
                 playlist = Playlist(
                     id = 3,
-                    title = "Playlist 3",
-                    description = "Description 3",
+                    title = "Learning CI/CD",
+                    description = "Educational roadmap",
                     items = emptyList(),
+                    category = PlaylistCategory.ROADMAP_PLAYLIST,
                     position = 2
                 ),
                 selectable = true,

--- a/gabimoreno/src/test/java/soy/gabimoreno/data/local/playlist/LocalPlaylistDataSourceTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/data/local/playlist/LocalPlaylistDataSourceTest.kt
@@ -110,10 +110,11 @@ class LocalPlaylistDataSourceTest {
     fun `GIVEN valid playlist WHEN getPlaylistById THEN mapped playlist is emitted`() = runTest {
         val playlist = buildPlaylist()
         val playlistDbModel = PlaylistDbModel(
-            playlist.id,
-            playlist.title,
-            playlist.description,
-            playlist.position,
+            id = playlist.id,
+            categoryId = playlist.category.id,
+            description = playlist.description,
+            position = playlist.position,
+            title = playlist.title,
         )
         val itemsDbModel = playlist.items.map {
             PlaylistItemsDbModel(


### PR DESCRIPTION
### :tophat: How was this resolved?

This commit introduces the `PlaylistCategory` enum, which is now used to categorize playlists. The `Playlist` model has been updated to include a `category` field of this type.

Key changes:
- Added `PlaylistCategory` enum with `USER_PLAYLIST` and `ROADMAP_PLAYLIST` categories.
- Updated `PlaylistDbModel` to include `categoryId`.
- Modified mappers to handle the new `category` field.
- Updated `PlaylistItem` composable to use category-specific colors and icons.
- Updated database schema version to 5.
