### PR TITLE
feat: Enable playlist reordering

### DIFF
--- a/gabimoreno/build.gradle.kts
+++ b/gabimoreno/build.gradle.kts
@@ -168,6 +168,7 @@ dependencies {
     implementation(libs.paging.compose)
     implementation(libs.playinapp.review)
     implementation(libs.playinapp.review.ktx)
+    implementation(libs.reorderable)
 
     testImplementation(libs.junit)
     testImplementation(libs.kluent)

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/local/playlist/LocalPlaylistDataSource.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/local/playlist/LocalPlaylistDataSource.kt
@@ -13,6 +13,7 @@ import soy.gabimoreno.data.local.GabiMorenoDatabase
 import soy.gabimoreno.data.local.audiocourse.model.AudioCourseDbModel
 import soy.gabimoreno.data.local.audiocourse.model.AudioCourseItemDbModel
 import soy.gabimoreno.data.local.mapper.toPlaylistAudioItem
+import soy.gabimoreno.data.local.mapper.toPlaylistDbModel
 import soy.gabimoreno.data.local.mapper.toPlaylistMapper
 import soy.gabimoreno.data.local.playlist.model.PlaylistDbModel
 import soy.gabimoreno.data.local.playlist.model.PlaylistItemsDbModel
@@ -106,6 +107,14 @@ class LocalPlaylistDataSource @Inject constructor(
         withContext(dispatcher) {
             playlistTransactionDao.getPlaylistIdsByItemId(audioItemId)
         }
+
+    suspend fun upsertPlaylistDbModels(
+        playlists: List<Playlist>
+    ) = withContext(dispatcher) {
+        playlistDbModelDao.upsertPlaylistDbModels(
+            playlists.map { it.toPlaylistDbModel() }
+        )
+    }
 
     suspend fun upsertPlaylistItemsDbModel(
         audioId: String,

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/playlist/DefaultPlaylistRepository.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/playlist/DefaultPlaylistRepository.kt
@@ -39,6 +39,11 @@ class DefaultPlaylistRepository @Inject constructor(
             .let { Either.Right(it) }
     }
 
+    override suspend fun upsertPlaylists(playlists: List<Playlist>): Either<Throwable, Unit> {
+        return localPlaylistDataSource.upsertPlaylistDbModels(playlists)
+            .let { Either.Right(Unit) }
+    }
+
     override suspend fun upsertPlaylistItems(
         audioId: String,
         playlistIds: List<Int>

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/playlist/PlaylistRepository.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/playlist/PlaylistRepository.kt
@@ -11,6 +11,7 @@ interface PlaylistRepository {
     suspend fun getAllPlaylists(): Either<Throwable, List<Playlist>>
     fun getPlaylistById(idPlaylist: Int): Either<Throwable, Flow<Playlist?>>
     suspend fun getPlaylistIdsByItemId(audioItemId: String): Either<Throwable, List<Int>>
+    suspend fun upsertPlaylists(playlists: List<Playlist>): Either<Throwable, Unit>
     suspend fun upsertPlaylistItems(
         audioId: String,
         playlistIds: List<Int>

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/UpsertPlaylistsUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/UpsertPlaylistsUseCase.kt
@@ -1,0 +1,16 @@
+package soy.gabimoreno.domain.usecase
+
+import arrow.core.Either
+import soy.gabimoreno.domain.model.content.Playlist
+import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import javax.inject.Inject
+
+class UpsertPlaylistsUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    suspend operator fun invoke(
+        playlists: List<Playlist>
+    ): Either<Throwable, Unit> {
+        return repository.upsertPlaylists(playlists)
+    }
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/audio/PlaylistAudioItemScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/audio/PlaylistAudioItemScreen.kt
@@ -128,8 +128,7 @@ fun PlaylistAudioItem(
             Spacer(modifier = Modifier.padding(vertical = Spacing.s8))
             Box(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(bottom = Spacing.s64),
+                    .fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
                 when {

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/list/PlaylistAction.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/list/PlaylistAction.kt
@@ -1,5 +1,7 @@
 package soy.gabimoreno.presentation.screen.playlist.list
 
+import soy.gabimoreno.domain.model.content.Playlist
+
 sealed interface PlaylistAction {
     data object OnBackClicked : PlaylistAction
     data class OnItemClicked(val playlistId: Int) : PlaylistAction
@@ -8,4 +10,5 @@ sealed interface PlaylistAction {
     data object OnAddPlaylistDialogConfirm : PlaylistAction
     data class OnDialogTitleChange(val title: String) : PlaylistAction
     data class OnDialogDescriptionChange(val description: String) : PlaylistAction
+    data class OnItemDragFinish(val reorderedPlaylists: List<Playlist>) : PlaylistAction
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/list/PlaylistScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/list/PlaylistScreen.kt
@@ -1,6 +1,5 @@
 package soy.gabimoreno.presentation.screen.playlist.list
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
@@ -40,8 +38,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import soy.gabimoreno.R
 import soy.gabimoreno.framework.toast
+import soy.gabimoreno.presentation.screen.playlist.list.view.ReorderablePlaylistColumn
 import soy.gabimoreno.presentation.screen.playlist.view.PlaylistDialog
-import soy.gabimoreno.presentation.screen.playlist.view.PlaylistItem
 import soy.gabimoreno.presentation.theme.GabiMorenoTheme
 import soy.gabimoreno.presentation.theme.Orange
 import soy.gabimoreno.presentation.theme.Spacing
@@ -162,22 +160,15 @@ fun PlaylistScreen(
                 }
 
                 else -> {
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxSize(),
-                        verticalArrangement = Arrangement.spacedBy(Spacing.s16)
-                    ) {
-                        items(
-                            count = state.playlists.size,
-                            key = { state.playlists[it].id }) { index ->
-                            PlaylistItem(
-                                playlist = state.playlists[index],
-                                onItemClick = {
-                                    onAction(PlaylistAction.OnItemClicked(state.playlists[index].id))
-                                }
-                            )
+                    ReorderablePlaylistColumn(
+                        playlists = state.playlists,
+                        onItemClick = { playlistId ->
+                            onAction(PlaylistAction.OnItemClicked(playlistId))
+                        },
+                        onDragFinish = { playlists ->
+                            onAction(PlaylistAction.OnItemDragFinish(playlists))
                         }
-                    }
+                    )
                 }
             }
         }

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/list/view/ReorderablePlaylistColumn.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/list/view/ReorderablePlaylistColumn.kt
@@ -1,0 +1,125 @@
+package soy.gabimoreno.presentation.screen.playlist.list.view
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.DragHandle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
+import soy.gabimoreno.R
+import soy.gabimoreno.domain.model.content.Playlist
+import soy.gabimoreno.presentation.screen.playlist.view.PlaylistItem
+import soy.gabimoreno.presentation.screen.playlist.view.reorderable.ReorderHapticFeedbackType
+import soy.gabimoreno.presentation.screen.playlist.view.reorderable.buildAccessibilityActions
+import soy.gabimoreno.presentation.screen.playlist.view.reorderable.rememberReorderHapticFeedback
+import soy.gabimoreno.presentation.theme.PurpleDark
+import soy.gabimoreno.presentation.theme.Spacing
+
+@Composable
+fun ReorderablePlaylistColumn(
+    playlists: List<Playlist>,
+    onItemClick: (Int) -> Unit,
+    onDragFinish: (reorderedPlaylists: List<Playlist>) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val haptic = rememberReorderHapticFeedback()
+    var reorderedPlaylists by remember { mutableStateOf(playlists) }
+
+    val lazyListState = rememberLazyListState()
+    val reorderableLazyColumnState = rememberReorderableLazyListState(lazyListState) { from, to ->
+        reorderedPlaylists = reorderedPlaylists.toMutableList().apply {
+            add(to.index, removeAt(from.index))
+        }
+
+        haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        state = lazyListState,
+        contentPadding = PaddingValues(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        itemsIndexed(reorderedPlaylists, key = { _, item -> item.id }) { index, item ->
+            ReorderableItem(reorderableLazyColumnState, item.id) {
+                val interactionSource = remember { MutableInteractionSource() }
+                val labelUp = stringResource(R.string.accessibility_action_up)
+                val labelDown = stringResource(R.string.accessibility_action_down)
+
+                Box(
+                    modifier = Modifier
+                        .height(IntrinsicSize.Min)
+                        .semantics {
+                            customActions = buildAccessibilityActions(
+                                index = index,
+                                listSize = reorderedPlaylists.size,
+                                onReorder = { newList -> reorderedPlaylists = newList },
+                                reorderedPlaylists = reorderedPlaylists,
+                                labelUp = labelUp,
+                                labelDown = labelDown,
+                            )
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    PlaylistItem(
+                        playlist = reorderedPlaylists[index],
+                        onItemClick = {
+                            onItemClick(reorderedPlaylists[index].id)
+                        }
+                    )
+                    IconButton(
+                        modifier = Modifier
+                            .draggableHandle(
+                                onDragStarted = {
+                                    haptic.performHapticFeedback(ReorderHapticFeedbackType.START)
+                                },
+                                onDragStopped = {
+                                    haptic.performHapticFeedback(ReorderHapticFeedbackType.END)
+                                    onDragFinish(reorderedPlaylists.updatePositions())
+                                },
+                                interactionSource = interactionSource,
+                            )
+                            .align(Alignment.TopEnd)
+                            .clearAndSetSemantics { },
+                        onClick = {},
+                    ) {
+                        Icon(
+                            Icons.Rounded.DragHandle,
+                            contentDescription = stringResource(R.string.playlists_reorder),
+                            modifier = Modifier.size(Spacing.s32),
+                            tint = PurpleDark
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun List<Playlist>.updatePositions(): List<Playlist> =
+    mapIndexed { index, playlist ->
+        playlist.copy(position = index)
+    }

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/view/reorderable/BuildAccessibilityActions.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/view/reorderable/BuildAccessibilityActions.kt
@@ -1,0 +1,30 @@
+package soy.gabimoreno.presentation.screen.playlist.view.reorderable
+
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import soy.gabimoreno.domain.model.content.Playlist
+
+internal fun buildAccessibilityActions(
+    index: Int,
+    listSize: Int,
+    onReorder: (List<Playlist>) -> Unit,
+    reorderedPlaylists: List<Playlist>,
+    labelUp : String,
+    labelDown : String
+): List<CustomAccessibilityAction> = buildList {
+    if (index > 0) {
+        add(
+            CustomAccessibilityAction(labelUp) {
+                onReorder(reorderedPlaylists.moveItemOnList(index, index - 1))
+                true
+            }
+        )
+    }
+    if (index < listSize - 1) {
+        add(
+            CustomAccessibilityAction(labelDown) {
+                onReorder(reorderedPlaylists.moveItemOnList(index, index + 1))
+                true
+            }
+        )
+    }
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/view/reorderable/MoveItemOnList.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/view/reorderable/MoveItemOnList.kt
@@ -1,0 +1,6 @@
+package soy.gabimoreno.presentation.screen.playlist.view.reorderable
+
+internal fun <T> List<T>.moveItemOnList(fromIndex: Int, toIndex: Int): List<T> =
+    toMutableList().apply {
+        add(toIndex, removeAt(fromIndex))
+    }

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/view/reorderable/ReorderHapticFeedback.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/view/reorderable/ReorderHapticFeedback.kt
@@ -1,0 +1,28 @@
+package soy.gabimoreno.presentation.screen.playlist.view.reorderable
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.HapticFeedbackConstantsCompat
+import androidx.core.view.ViewCompat
+
+enum class ReorderHapticFeedbackType(val hapticConstant: Int) {
+    START(HapticFeedbackConstantsCompat.GESTURE_START),
+    MOVE(HapticFeedbackConstantsCompat.SEGMENT_FREQUENT_TICK),
+    END(HapticFeedbackConstantsCompat.GESTURE_END)
+}
+
+fun interface ReorderHapticFeedback {
+    fun performHapticFeedback(type: ReorderHapticFeedbackType)
+}
+
+@Composable
+fun rememberReorderHapticFeedback(): ReorderHapticFeedback {
+    val view = LocalView.current
+
+    return remember(view) {
+        ReorderHapticFeedback { type ->
+            ViewCompat.performHapticFeedback(view, type.hapticConstant)
+        }
+    }
+}

--- a/gabimoreno/src/main/res/values/strings.xml
+++ b/gabimoreno/src/main/res/values/strings.xml
@@ -92,4 +92,8 @@
     <string name="playlists_add_audio_to_playlist">Añadir a playlist</string>
     <string name="playlists_save">Guardar</string>
     <string name="playlists_success_message">Cambios guardados con éxito</string>
+    <string name="playlists_reorder">Reordenar item</string>
+    <string name="accessibility_action_up">Subir</string>
+    <string name="accessibility_action_down">Bajar</string>
+
 </resources>

--- a/gabimoreno/src/test/java/soy/gabimoreno/data/local/playlist/LocalPlaylistDataSourceTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/data/local/playlist/LocalPlaylistDataSourceTest.kt
@@ -38,6 +38,7 @@ import soy.gabimoreno.data.local.playlist.model.PlaylistWithItems
 import soy.gabimoreno.data.local.premiumaudio.LocalPremiumAudiosDataSource
 import soy.gabimoreno.data.local.premiumaudio.PremiumAudioDbModelDao
 import soy.gabimoreno.fake.buildPlaylist
+import soy.gabimoreno.fake.buildPlaylistDbModel
 
 class LocalPlaylistDataSourceTest {
 
@@ -181,6 +182,18 @@ class LocalPlaylistDataSourceTest {
                 playlistTransactionDao.getPlaylistIdsByItemId(playlist1.items.first().id)
             }
         }
+
+    @Test
+    fun `GIVEN valid data WHEN upsertPlaylistDbModels THEN upserts playlists`() = runTest {
+        val playlists = listOf(buildPlaylistDbModel(), buildPlaylistDbModel(2))
+        coJustRun { playlistDbModelDao.upsertPlaylistDbModels(playlists) }
+
+        playlistDataSource.upsertPlaylistDbModels(playlists.map { it.toPlaylistMapper(emptyList()) })
+
+        coVerifyOnce {
+            playlistDbModelDao.upsertPlaylistDbModels(playlists)
+        }
+    }
 
     @Test
     fun `GIVEN playlistIds WHEN upsertPlaylistItemsDbModel THEN upserts items with correct positions`() =

--- a/gabimoreno/src/test/java/soy/gabimoreno/data/remote/repository/DefaultPlaylistRepositoryTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/data/remote/repository/DefaultPlaylistRepositoryTest.kt
@@ -184,6 +184,39 @@ class DefaultPlaylistRepositoryTest {
         }
 
     @Test
+    fun `GIVEN valid data WHEN upsertPlaylists THEN upserts playlists`() =
+        runTest {
+            val playlists = listOf(buildPlaylist(), buildPlaylist(2))
+            coJustRun { localPlaylistDataSource.upsertPlaylistDbModels(playlists) }
+
+            val result = repository.upsertPlaylists(playlists)
+
+            result shouldBeEqualTo right(Unit)
+            coVerifyOnce {
+                localPlaylistDataSource.upsertPlaylistDbModels(playlists)
+            }
+        }
+
+    @Test
+    fun `GIVEN data source throws exception WHEN upsertPlaylists THEN Left with throwable is returned`() =
+        runTest {
+            val playlists = listOf(buildPlaylist(), buildPlaylist(2))
+            val exception = RuntimeException("Something went wrong")
+            coEvery {
+                localPlaylistDataSource.upsertPlaylistDbModels(playlists)
+            } throws exception
+
+            val result = runCatching {
+                repository.upsertPlaylists(playlists)
+            }.getOrDefault(left(exception))
+
+            result shouldBeEqualTo left(exception)
+            coVerifyOnce {
+                localPlaylistDataSource.upsertPlaylistDbModels(playlists)
+            }
+        }
+
+    @Test
     fun `GIVEN playlistIds WHEN upsertPlaylistItemsDbModel THEN upserts items with correct positions`() =
         runTest {
             val playlistItemId = "audio-123"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/UpsertPlaylistsUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/UpsertPlaylistsUseCaseTest.kt
@@ -1,0 +1,53 @@
+package soy.gabimoreno.domain.usecase
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Before
+import org.junit.Test
+import soy.gabimoreno.core.testing.coVerifyOnce
+import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.ext.left
+import soy.gabimoreno.ext.right
+import soy.gabimoreno.fake.buildPlaylist
+
+class UpsertPlaylistsUseCaseTest {
+
+    private val repository = mockk<PlaylistRepository>()
+    private lateinit var useCase: UpsertPlaylistsUseCase
+
+    @Before
+    fun setUp() {
+        useCase = UpsertPlaylistsUseCase(repository)
+    }
+
+    @Test
+    fun `GIVEN valid list of playlist WHEN invoke THEN Right unit is returned`() = runTest {
+        val playlists = listOf(buildPlaylist(), buildPlaylist(2))
+        coEvery { repository.upsertPlaylists(playlists) } returns right(Unit)
+
+        val result = useCase(playlists)
+
+        result shouldBeEqualTo right(Unit)
+        coVerifyOnce {
+            repository.upsertPlaylists(playlists)
+        }
+    }
+
+    @Test
+    fun `GIVEN repository fails WHEN invoke THEN Left with throwable is returned`() = runTest {
+        val playlists = listOf(buildPlaylist(), buildPlaylist(2))
+        val exception = IllegalStateException("unexpected failure")
+        coEvery { repository.upsertPlaylists(playlists) } throws exception
+
+        val result = runCatching {
+            useCase(playlists)
+        }.getOrDefault(left(exception))
+
+        result shouldBeEqualTo left(exception)
+        coVerifyOnce {
+            repository.upsertPlaylists(playlists)
+        }
+    }
+}

--- a/gabimoreno/src/test/java/soy/gabimoreno/fake/FakePlaylist.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/fake/FakePlaylist.kt
@@ -1,5 +1,6 @@
 package soy.gabimoreno.fake
 
+import soy.gabimoreno.data.local.playlist.model.PlaylistDbModel
 import soy.gabimoreno.data.remote.model.Category
 import soy.gabimoreno.domain.model.audio.Saga
 import soy.gabimoreno.domain.model.content.Playlist
@@ -11,6 +12,13 @@ fun buildPlaylist(id: Int = 1) = Playlist(
     description = "This is a description",
     items = buildPlaylistItems(),
     position = 0
+)
+
+fun buildPlaylistDbModel(id: Int = 1) = PlaylistDbModel(
+    id = id,
+    title = "This is a title",
+    description = "This is a description",
+    position = id - 1
 )
 
 fun buildNewPlaylist(id: Int = 1) = Playlist(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ turbine = "0.12.3"
 json = "20250107"
 pagingCompose = "3.3.6"
 play-review = "2.0.2"
+reorderable = "2.5.1"
 
 [libraries]
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
@@ -76,6 +77,8 @@ compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview"
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room-runtime" }
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room-runtime" }
 room-paging = { module = "androidx.room:room-paging", version.ref = "room-runtime" }
+
+reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow-core" }
 
@@ -119,6 +122,7 @@ firebase-messaging = { module = "com.google.firebase:firebase-messaging-ktx" }
 
 playinapp-review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "play-review" }
 playinapp-review = { module = "com.google.android.play:review", version.ref = "play-review" }
+
 
 # Tests
 junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
### :tophat: How was this resolved?

This commit introduces the ability to reorder playlists within the app.

Key changes include:
- Added `sh.calvin.reorderable:reorderable` dependency for drag-and-drop functionality.
- Implemented `ReorderablePlaylistColumn` composable to display and reorder playlists.
- Updated `PlaylistViewModel` and `PlaylistRepository` to handle playlist reordering logic.
- Added new string resources for accessibility actions related to reordering.
- Added unit tests for the new reordering functionality.

