### PR TITLE
refactor: Optimize load premium audios

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/data/remote/service/PostService.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/remote/service/PostService.kt
@@ -10,6 +10,7 @@ interface PostService {
     @GET("wp-json/wp/v2/posts/")
     suspend fun getPosts(
         @Query("categories") categoriesQuery: String,
+        @Query("_fields") fieldsQuery: String = FIELDS,
         @Query("per_page") postsPerPage: Int = POSTS_PER_PAGE,
         @Query("page") page: Int = POSTS_PAGE
     ): List<PostApiModel>
@@ -24,3 +25,4 @@ interface PostService {
 
 internal const val POSTS_PER_PAGE = 20
 internal const val POSTS_PAGE = 1
+private const val FIELDS = "id,title,content,excerpt,author,categories,link,date"

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/premiumaudios/DefaultPremiumAudiosRepository.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/premiumaudios/DefaultPremiumAudiosRepository.kt
@@ -77,6 +77,6 @@ class DefaultPremiumAudiosRepository @Inject constructor(
     }
 }
 
-private const val MAX_ITEMS = 20
+private const val MAX_ITEMS = 10
 private const val PREFETCH_ITEMS = 20
 internal const val TWELVE_HOURS_IN_MILLIS = 12 * 60 * 60 * 1000L


### PR DESCRIPTION
### :tophat: How was this resolved?

Reduce the number of audios requested on the first load by the `PostService` from 20 to 10.
It also specifies the fields to be returned by the API to reduce the amount of data transferred.
