### PR TITLE
refactor: Optimize load audiocourses

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/data/remote/service/PostService.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/remote/service/PostService.kt
@@ -18,6 +18,7 @@ interface PostService {
     @GET("wp-json/wp/v2/posts/")
     suspend fun getAudioCourses(
         @Query("categories") categoriesQuery: String,
+        @Query("_fields") fieldsQuery: String = "$FIELDS,$IMAGE_FIELD",
         @Query("per_page") postsPerPage: Int = POSTS_PER_PAGE,
         @Query("page") page: Int = POSTS_PAGE,
     ): List<CourseApiModel>
@@ -26,3 +27,4 @@ interface PostService {
 internal const val POSTS_PER_PAGE = 20
 internal const val POSTS_PAGE = 1
 private const val FIELDS = "id,title,content,excerpt,author,categories,link,date"
+private const val IMAGE_FIELD = "yoast_head_json.og_image"

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/audio/PlaylistAudioItemScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/audio/PlaylistAudioItemScreen.kt
@@ -185,7 +185,7 @@ fun PlaylistAudioItem(
                     text = stringResource(R.string.playlists_save),
                     height = Spacing.s48,
                     modifier = Modifier
-                        .padding(bottom = Spacing.s8)
+                        .padding(bottom = Spacing.s64)
                         .align(Alignment.BottomCenter),
                     onClick = { onAction(PlaylistAudioItemAction.OnSaveClicked) },
                 )


### PR DESCRIPTION
### :tophat: How was this resolved?

Specifies the fields to be returned by the API on audiocourses request to reduce the amount of data transferred.

Added more padding bottom on save playlist audio button. Previously if we are playing an audio, we can't push this button. 