### PR TITLE
Refactor: Sync audio state with Firestore

### DIFF
--- a/gabimoreno/build.gradle.kts
+++ b/gabimoreno/build.gradle.kts
@@ -142,6 +142,7 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
     implementation(libs.firebase.analytics)
+    implementation(libs.firebase.firestore)
     implementation(libs.firebase.messaging)
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/datasource/AudioCoursesCloudDataSource.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/datasource/AudioCoursesCloudDataSource.kt
@@ -1,0 +1,24 @@
+package soy.gabimoreno.data.cloud.audiosync.datasource
+
+import soy.gabimoreno.data.cloud.audiosync.response.SyncableAudiocourseResponse
+import javax.inject.Inject
+
+class AudioCoursesCloudDataSource @Inject constructor(
+    private val cloudDataSource: CloudDataSource<SyncableAudiocourseResponse>
+) {
+    suspend fun getAudioCoursesItems(email: String): List<SyncableAudiocourseResponse> {
+        return cloudDataSource.getAudioItems(email, AUDIOCOURSES_PATH)
+    }
+
+    fun upsertAudioCourseItemFields(email: String, itemId: String, updates: Map<String, Any>) {
+        cloudDataSource.upsertAudioItemFields(email, AUDIOCOURSES_PATH, itemId, updates)
+    }
+
+    suspend fun batchUpdateFieldsForAllAudioCoursesItems(email: String, updates: Map<String, Any>) {
+        cloudDataSource.batchUpdateFieldsForAllItems<SyncableAudiocourseResponse>(
+            email,
+            AUDIOCOURSES_PATH,
+            updates
+        )
+    }
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/datasource/CloudAudioSyncDataSource.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/datasource/CloudAudioSyncDataSource.kt
@@ -1,0 +1,82 @@
+package soy.gabimoreno.data.cloud.audiosync.datasource
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+import com.google.firebase.firestore.toObjects
+import kotlinx.coroutines.tasks.await
+import soy.gabimoreno.data.cloud.audiosync.response.SyncableAudio
+import javax.inject.Inject
+
+class CloudDataSource<T : SyncableAudio> @Inject constructor(
+    val firestore: FirebaseFirestore,
+) {
+    suspend inline fun <reified T : SyncableAudio> getAudioItems(
+        email: String,
+        collectionPath: String
+    ): List<T> {
+        return firestore.collection(USERS_PATH)
+            .document(email)
+            .collection(collectionPath)
+            .get()
+            .await()
+            .toObjects<T>()
+    }
+
+    fun upsertAudioItemFields(
+        email: String,
+        collectionPath: String,
+        itemId: String,
+        updates: Map<String, Any>
+    ) {
+        firestore.collection(USERS_PATH)
+            .document(email)
+            .collection(collectionPath)
+            .document(itemId)
+            .set(
+                updates,
+                SetOptions.merge()
+            )
+    }
+
+    suspend inline fun <reified T : SyncableAudio> batchUpdateFieldsForAllItems(
+        email: String,
+        collectionPath: String,
+        updates: Map<String, Any>
+    ) {
+        val documentsSnapshot = firestore.collection(USERS_PATH)
+            .document(email)
+            .collection(collectionPath)
+            .get()
+            .await()
+
+        val batch = firestore.batch()
+
+        documentsSnapshot.documents.forEach { document ->
+            batch.update(document.reference, updates)
+        }
+
+        batch.commit()
+    }
+
+    fun deleteAudioItem(email: String, collectionPath: String, itemId: String) {
+        firestore.collection(USERS_PATH)
+            .document(email)
+            .collection(collectionPath)
+            .document(itemId)
+            .delete()
+    }
+
+    suspend inline fun <reified T : SyncableAudio> deleteAllAudioItems(
+        email: String,
+        collectionPath: String
+    ) {
+        val items = getAudioItems<T>(email, collectionPath)
+        items.forEach { item ->
+            deleteAudioItem(email, collectionPath, item.id)
+        }
+    }
+}
+
+const val AUDIOCOURSES_PATH = "audiocourses"
+const val PREMIUM_AUDIOS_PATH = "premium_audios"
+const val USERS_PATH = "base_users"

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/datasource/PremiumAudiosCloudDataSource.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/datasource/PremiumAudiosCloudDataSource.kt
@@ -1,0 +1,24 @@
+package soy.gabimoreno.data.cloud.audiosync.datasource
+
+import soy.gabimoreno.data.cloud.audiosync.response.SyncablePremiumAudioResponse
+import javax.inject.Inject
+
+class PremiumAudiosCloudDataSource @Inject constructor(
+    private val cloudDataSource: CloudDataSource<SyncablePremiumAudioResponse>
+) {
+    suspend fun getPremiumAudioItems(email: String): List<SyncablePremiumAudioResponse> {
+        return cloudDataSource.getAudioItems(email, PREMIUM_AUDIOS_PATH)
+    }
+
+    fun upsertPremiumAudioItemFields(email: String, itemId: String, updates: Map<String, Any>) {
+        cloudDataSource.upsertAudioItemFields(email, PREMIUM_AUDIOS_PATH, itemId, updates)
+    }
+
+    suspend fun batchUpdateFieldsForAllPremiumAudioItems(email: String, updates: Map<String, Any>) {
+        cloudDataSource.batchUpdateFieldsForAllItems<SyncablePremiumAudioResponse>(
+            email,
+            PREMIUM_AUDIOS_PATH,
+            updates
+        )
+    }
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/response/SyncableAudio.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/response/SyncableAudio.kt
@@ -1,0 +1,7 @@
+package soy.gabimoreno.data.cloud.audiosync.response
+
+interface SyncableAudio {
+    val id: String
+    val hasBeenListened: Boolean
+    val markedAsFavorite: Boolean
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/response/SyncableAudiocourseResponse.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/response/SyncableAudiocourseResponse.kt
@@ -1,0 +1,7 @@
+package soy.gabimoreno.data.cloud.audiosync.response
+
+data class SyncableAudiocourseResponse(
+    override val id: String = "",
+    override val hasBeenListened: Boolean = false,
+    override val markedAsFavorite: Boolean = false
+) : SyncableAudio

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/response/SyncablePremiumAudioResponse.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/response/SyncablePremiumAudioResponse.kt
@@ -1,0 +1,7 @@
+package soy.gabimoreno.data.cloud.audiosync.response
+
+data class SyncablePremiumAudioResponse(
+    override val id: String = "",
+    override val hasBeenListened: Boolean = false,
+    override val markedAsFavorite: Boolean = false,
+) : SyncableAudio

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/datasource/CloudPlaylistDataSource.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/datasource/CloudPlaylistDataSource.kt
@@ -1,0 +1,89 @@
+package soy.gabimoreno.data.cloud.playlist.datasource
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.toObjects
+import kotlinx.coroutines.tasks.await
+import soy.gabimoreno.data.cloud.audiosync.datasource.USERS_PATH
+import soy.gabimoreno.data.cloud.playlist.response.CloudPlaylistItemResponse
+import soy.gabimoreno.data.cloud.playlist.response.CloudPlaylistResponse
+import javax.inject.Inject
+
+class CloudPlaylistDataSource @Inject constructor(
+    private val firestore: FirebaseFirestore,
+) {
+    suspend fun getPlaylists(email: String): List<CloudPlaylistResponse> {
+        return firestore.collection(USERS_PATH)
+            .document(email)
+            .collection(PLAYLISTS_PATH)
+            .get()
+            .await()
+            .toObjects<CloudPlaylistResponse>()
+    }
+
+    suspend fun savePlaylist(email: String, playlist: CloudPlaylistResponse) {
+        firestore.collection(USERS_PATH)
+            .document(email)
+            .collection(PLAYLISTS_PATH)
+            .document(playlist.playlistId)
+            .set(playlist)
+            .await()
+    }
+
+    suspend fun deletePlaylist(email: String, playlistId: String) {
+        deleteAllPlaylistItems(email, playlistId)
+
+        firestore.collection(USERS_PATH)
+            .document(email)
+            .collection(PLAYLISTS_PATH)
+            .document(playlistId)
+            .delete()
+            .await()
+    }
+
+    suspend fun getPlaylistItems(
+        email: String,
+        playlistId: String
+    ): List<CloudPlaylistItemResponse> {
+        return firestore.collection(USERS_PATH)
+            .document(email)
+            .collection(PLAYLISTS_PATH)
+            .document(playlistId)
+            .collection(PLAYLIST_ITEMS_PATH)
+            .orderBy("position")
+            .get()
+            .await()
+            .toObjects<CloudPlaylistItemResponse>()
+    }
+
+    suspend fun savePlaylistItem(email: String, playlistItem: CloudPlaylistItemResponse) {
+        firestore.collection(USERS_PATH)
+            .document(email)
+            .collection(PLAYLISTS_PATH)
+            .document(playlistItem.playlistId)
+            .collection(PLAYLIST_ITEMS_PATH)
+            .document(playlistItem.id.toString())
+            .set(playlistItem)
+            .await()
+    }
+
+    suspend fun deletePlaylistItem(email: String, playlistId: String, itemId: Int) {
+        firestore.collection(USERS_PATH)
+            .document(email)
+            .collection(PLAYLISTS_PATH)
+            .document(playlistId)
+            .collection(PLAYLIST_ITEMS_PATH)
+            .document(itemId.toString())
+            .delete()
+            .await()
+    }
+
+    private suspend fun deleteAllPlaylistItems(email: String, playlistId: String) {
+        val items = getPlaylistItems(email, playlistId)
+        items.forEach { item ->
+            deletePlaylistItem(email, playlistId, item.id)
+        }
+    }
+}
+
+private const val PLAYLISTS_PATH = "playlists"
+private const val PLAYLIST_ITEMS_PATH = "items"

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/response/CloudPlaylistItemResponse.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/response/CloudPlaylistItemResponse.kt
@@ -1,0 +1,8 @@
+package soy.gabimoreno.data.cloud.playlist.response
+
+data class CloudPlaylistItemResponse(
+    val id: Int = -1,
+    val audioItemId: String = "",
+    val playlistId: String = "",
+    val position: Int = -1,
+)

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/response/CloudPlaylistResponse.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/response/CloudPlaylistResponse.kt
@@ -1,0 +1,9 @@
+package soy.gabimoreno.data.cloud.playlist.response
+
+data class CloudPlaylistResponse(
+    val playlistId: String = "",
+    val categoryId: Int = -1,
+    val description: String = "",
+    val position: Int = -1,
+    val title: String = ""
+)

--- a/gabimoreno/src/main/java/soy/gabimoreno/di/DataStoreModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/DataStoreModule.kt
@@ -6,20 +6,29 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
+import soy.gabimoreno.domain.repository.premiumaudios.PremiumAudiosRepository
 import soy.gabimoreno.domain.session.MemberSession
+import soy.gabimoreno.domain.usecase.CheckShouldIShowInAppReviewUseCase
+import soy.gabimoreno.domain.usecase.GetAudioCoursesUseCase
+import soy.gabimoreno.domain.usecase.GetInAppReviewCounterUseCase
 import soy.gabimoreno.domain.usecase.GetLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase
+import soy.gabimoreno.domain.usecase.GetPremiumAudiosManagedUseCase
 import soy.gabimoreno.domain.usecase.GetShouldIReloadAudioCoursesUseCase
 import soy.gabimoreno.domain.usecase.GetShouldIReversePodcastOrderUseCase
-import soy.gabimoreno.domain.usecase.CheckShouldIShowInAppReviewUseCase
-import soy.gabimoreno.domain.usecase.GetInAppReviewCounterUseCase
 import soy.gabimoreno.domain.usecase.IsBearerTokenValid
+import soy.gabimoreno.domain.usecase.MarkAudioCourseItemAsListenedUseCase
+import soy.gabimoreno.domain.usecase.MarkPremiumAudioAsListenedUseCase
 import soy.gabimoreno.domain.usecase.ResetJwtAuthTokenUseCase
 import soy.gabimoreno.domain.usecase.SaveCredentialsInDataStoreUseCase
 import soy.gabimoreno.domain.usecase.SaveLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase
+import soy.gabimoreno.domain.usecase.SetAllAudiocoursesAsUnlistenedUseCase
+import soy.gabimoreno.domain.usecase.SetAllPremiumAudiosAsUnlistenedUseCase
 import soy.gabimoreno.domain.usecase.SetJwtAuthTokenUseCase
 import soy.gabimoreno.domain.usecase.SetShouldIReloadAudioCoursesUseCase
 import soy.gabimoreno.domain.usecase.SetShouldIReversePodcastOrderUseCase
 import soy.gabimoreno.domain.usecase.SetShouldIShowInAppReviewUseCase
+import soy.gabimoreno.domain.usecase.UpdateAudioItemFavoriteStateUseCase
 import soy.gabimoreno.framework.datastore.DataStoreMemberSession
 import javax.inject.Singleton
 
@@ -110,4 +119,75 @@ object DataStoreModule {
     fun provideSetShouldIShowInAppReviewUseCase(
         @ApplicationContext context: Context,
     ) = SetShouldIShowInAppReviewUseCase(context)
+
+    @Provides
+    @Singleton
+    fun provideUpdateAudioItemFavoriteStateUseCase(
+        audioCoursesRepository: AudioCoursesRepository,
+        premiumAudiosRepository: PremiumAudiosRepository,
+        @ApplicationContext context: Context,
+    ): UpdateAudioItemFavoriteStateUseCase = UpdateAudioItemFavoriteStateUseCase(
+        audioCoursesRepository = audioCoursesRepository,
+        context = context,
+        premiumAudioCoursesRepository = premiumAudiosRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideGetAudioCoursesUseCase(
+        audioCoursesRepository: AudioCoursesRepository,
+        @ApplicationContext context: Context,
+    ): GetAudioCoursesUseCase =
+        GetAudioCoursesUseCase(context = context, audioCoursesRepository = audioCoursesRepository)
+
+    @Provides
+    @Singleton
+    fun provideMarkAudioCourseItemAsListenedUseCase(
+        audioCoursesRepository: AudioCoursesRepository,
+        @ApplicationContext context: Context,
+    ): MarkAudioCourseItemAsListenedUseCase =
+        MarkAudioCourseItemAsListenedUseCase(
+            context = context,
+            audioCoursesRepository = audioCoursesRepository
+        )
+
+    @Provides
+    @Singleton
+    fun provideSetAllAudiocoursesAsUnlistenedUseCase(
+        audioCoursesRepository: AudioCoursesRepository,
+        @ApplicationContext context: Context,
+    ): SetAllAudiocoursesAsUnlistenedUseCase = SetAllAudiocoursesAsUnlistenedUseCase(
+        context = context,
+        audioCoursesRepository = audioCoursesRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideMarkPremiumAudioAsListenedUseCase(
+        premiumAudiosRepository: PremiumAudiosRepository,
+        @ApplicationContext context: Context,
+    ): MarkPremiumAudioAsListenedUseCase = MarkPremiumAudioAsListenedUseCase(
+        context = context,
+        premiumAudiosRepository = premiumAudiosRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideSetAllPremiumAudiosAsUnlistenedUseCase(
+        premiumAudiosRepository: PremiumAudiosRepository,
+        @ApplicationContext context: Context,
+    ): SetAllPremiumAudiosAsUnlistenedUseCase = SetAllPremiumAudiosAsUnlistenedUseCase(
+        context = context,
+        premiumAudiosRepository = premiumAudiosRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideGetPremiumAudiosManagedUseCase(
+        @ApplicationContext context: Context,
+        premiumAudiosRepository: PremiumAudiosRepository,
+    ): GetPremiumAudiosManagedUseCase = GetPremiumAudiosManagedUseCase(
+        context = context,
+        premiumAudiosRepository = premiumAudiosRepository
+    )
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/di/FirebaseModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/FirebaseModule.kt
@@ -1,0 +1,18 @@
+package soy.gabimoreno.di
+
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FirebaseModule {
+
+    @Provides
+    @Singleton
+    fun provideFirestore() = Firebase.firestore
+}

--- a/gabimoreno/src/main/java/soy/gabimoreno/di/data/RepositoryModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/data/RepositoryModule.kt
@@ -4,6 +4,8 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import soy.gabimoreno.data.cloud.audiosync.datasource.AudioCoursesCloudDataSource
+import soy.gabimoreno.data.cloud.audiosync.datasource.PremiumAudiosCloudDataSource
 import soy.gabimoreno.data.local.audiocourse.LocalAudioCoursesDataSource
 import soy.gabimoreno.data.local.playlist.LocalPlaylistDataSource
 import soy.gabimoreno.data.local.premiumaudio.LocalPremiumAudiosDataSource
@@ -38,11 +40,13 @@ object RepositoryModule {
     @Provides
     @Singleton
     fun provideContentRepository(
+        cloudDataSource: PremiumAudiosCloudDataSource,
         localPremiumAudiosDataSource: LocalPremiumAudiosDataSource,
         remotePremiumAudiosDataSource: RemotePremiumAudiosDataSource,
         refreshPremiumAudiosFromRemoteUseCase: RefreshPremiumAudiosFromRemoteUseCase,
         saveLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase: SaveLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase,
     ): PremiumAudiosRepository = DefaultPremiumAudiosRepository(
+        cloudDataSource,
         localPremiumAudiosDataSource,
         remotePremiumAudiosDataSource,
         refreshPremiumAudiosFromRemoteUseCase,
@@ -62,10 +66,12 @@ object RepositoryModule {
     @Provides
     @Singleton
     fun provideAudioCoursesRepository(
+        cloudDataSource: AudioCoursesCloudDataSource,
         localAudioCoursesDataSource: LocalAudioCoursesDataSource,
         remoteAudioCoursesDataSource: RemoteAudioCoursesDataSource,
         refreshPremiumAudiosFromRemoteUseCase: RefreshPremiumAudiosFromRemoteUseCase,
     ): AudioCoursesRepository = DefaultAudioCoursesRepository(
+        cloudDataSource,
         localAudioCoursesDataSource,
         remoteAudioCoursesDataSource,
         refreshPremiumAudiosFromRemoteUseCase

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/audiocourses/AudioCoursesRepository.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/audiocourses/AudioCoursesRepository.kt
@@ -9,14 +9,18 @@ import soy.gabimoreno.domain.model.content.AudioCourseItem
 interface AudioCoursesRepository {
     suspend fun getCourses(
         categories: List<Category>,
+        email: String,
         forceRefresh: Boolean = false
     ): Either<Throwable, List<AudioCourse>>
-
     suspend fun getCourseById(idCourse: String): Either<Throwable, Flow<AudioCourse>>
     suspend fun getAudioCourseItem(audioCourseItemId: String): Either<Throwable, AudioCourseItem>
     suspend fun getAllFavoriteAudioCoursesItems(): Either<Throwable, List<AudioCourseItem>>
-    suspend fun markAudioCourseItemAsListened(id: String, hasBeenListened: Boolean)
-    suspend fun markAllAudioCourseItemsAsUnlistened()
+    suspend fun markAudioCourseItemAsListened(
+        audioCourseId: String,
+        email: String,
+        hasBeenListened: Boolean
+    )
+    suspend fun markAllAudioCourseItemsAsUnlistened(email: String)
     suspend fun reset()
-    suspend fun updateMarkedAsFavorite(id: String, isFavorite: Boolean)
+    suspend fun updateMarkedAsFavorite(audioCourseId: String, email: String, isFavorite: Boolean)
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/premiumaudios/PremiumAudiosRepository.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/premiumaudios/PremiumAudiosRepository.kt
@@ -9,11 +9,21 @@ import soy.gabimoreno.domain.model.content.PremiumAudio
 interface PremiumAudiosRepository {
     suspend fun getPremiumAudioMediator(
         categories: List<Category>,
+        email: String,
     ): Either<Throwable, Flow<PagingData<PremiumAudio>>>
 
-    suspend fun getPremiumAudioById(idPremiumAudio: String): Either<Throwable, PremiumAudio>
+    suspend fun getPremiumAudioById(premiumAudioId: String): Either<Throwable, PremiumAudio>
     suspend fun getAllFavoritePremiumAudios(): Either<Throwable, List<PremiumAudio>>
-    suspend fun markAllPremiumAudiosAsUnlistened()
-    suspend fun markPremiumAudioAsListened(id: String, hasBeenListened: Boolean)
-    suspend fun markPremiumAudioAsFavorite(id: String, isFavorite: Boolean)
+    suspend fun markAllPremiumAudiosAsUnlistened(email: String)
+    suspend fun markPremiumAudioAsListened(
+        email: String,
+        premiumAudioId: String,
+        hasBeenListened: Boolean,
+    )
+
+    suspend fun markPremiumAudioAsFavorite(
+        email: String,
+        premiumAudioId: String,
+        isFavorite: Boolean,
+    )
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetAudioCoursesUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetAudioCoursesUseCase.kt
@@ -1,18 +1,27 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.data.remote.model.Category
 import soy.gabimoreno.domain.model.content.AudioCourse
 import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class GetAudioCoursesUseCase @Inject constructor(
-    private val audioCoursesRepository: AudioCoursesRepository
+    private val audioCoursesRepository: AudioCoursesRepository,
+    private val context: Context,
 ) {
     suspend operator fun invoke(
         categories: List<Category>,
         forceRefresh: Boolean = false
     ): Either<Throwable, List<AudioCourse>> {
-        return audioCoursesRepository.getCourses(categories, forceRefresh)
+        val email = context.getEmail().first()
+        return audioCoursesRepository.getCourses(
+            categories = categories,
+            email = email,
+            forceRefresh = forceRefresh
+        )
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetPremiumAudiosManagedUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetPremiumAudiosManagedUseCase.kt
@@ -1,18 +1,23 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import androidx.paging.PagingData
 import arrow.core.Either
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.data.remote.model.Category
 import soy.gabimoreno.domain.model.content.PremiumAudio
 import soy.gabimoreno.domain.repository.premiumaudios.PremiumAudiosRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class GetPremiumAudiosManagedUseCase @Inject constructor(
+    private val context: Context,
     private val premiumAudiosRepository: PremiumAudiosRepository,
 ) {
     suspend operator fun invoke(categories: List<Category>):
-            Either<Throwable, Flow<PagingData<PremiumAudio>>> {
-        return premiumAudiosRepository.getPremiumAudioMediator(categories)
+        Either<Throwable, Flow<PagingData<PremiumAudio>>> {
+        val email = context.getEmail().first()
+        return premiumAudiosRepository.getPremiumAudioMediator(categories, email)
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/MarkAudioCourseItemAsListenedUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/MarkAudioCourseItemAsListenedUseCase.kt
@@ -1,13 +1,22 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 
 class MarkAudioCourseItemAsListenedUseCase @Inject constructor(
-    private val audioCoursesRepository: AudioCoursesRepository
+    private val audioCoursesRepository: AudioCoursesRepository,
+    private val context: Context,
 ) {
     suspend operator fun invoke(idAudioCourseItem: String, hasBeenListened: Boolean) {
-        audioCoursesRepository.markAudioCourseItemAsListened(idAudioCourseItem, hasBeenListened)
+        val email = context.getEmail().first()
+        audioCoursesRepository.markAudioCourseItemAsListened(
+            audioCourseId = idAudioCourseItem,
+            email = email,
+            hasBeenListened = hasBeenListened
+        )
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/MarkPremiumAudioAsListenedUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/MarkPremiumAudioAsListenedUseCase.kt
@@ -1,12 +1,21 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.repository.premiumaudios.PremiumAudiosRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class MarkPremiumAudioAsListenedUseCase @Inject constructor(
+    private val context: Context,
     private val premiumAudiosRepository: PremiumAudiosRepository
 ) {
-    suspend operator fun invoke(idPremiumAudio: String, hasBeenListened: Boolean) {
-        premiumAudiosRepository.markPremiumAudioAsListened(idPremiumAudio, hasBeenListened)
+    suspend operator fun invoke(premiumAudioId: String, hasBeenListened: Boolean) {
+        val email = context.getEmail().first()
+        premiumAudiosRepository.markPremiumAudioAsListened(
+            email = email,
+            premiumAudioId = premiumAudioId,
+            hasBeenListened = hasBeenListened
+        )
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetAllAudiocoursesAsUnlistenedUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetAllAudiocoursesAsUnlistenedUseCase.kt
@@ -1,12 +1,17 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class SetAllAudiocoursesAsUnlistenedUseCase @Inject constructor(
     private val audioCoursesRepository: AudioCoursesRepository,
+    private val context: Context,
 ) {
     suspend operator fun invoke() {
-        audioCoursesRepository.markAllAudioCourseItemsAsUnlistened()
+        val email = context.getEmail().first()
+        audioCoursesRepository.markAllAudioCourseItemsAsUnlistened(email = email)
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetAllPremiumAudiosAsUnlistenedUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetAllPremiumAudiosAsUnlistenedUseCase.kt
@@ -1,12 +1,17 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.repository.premiumaudios.PremiumAudiosRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class SetAllPremiumAudiosAsUnlistenedUseCase @Inject constructor(
+    private val context: Context,
     private val premiumAudiosRepository: PremiumAudiosRepository,
 ) {
     suspend operator fun invoke() {
-        premiumAudiosRepository.markAllPremiumAudiosAsUnlistened()
+        val email = context.getEmail().first()
+        premiumAudiosRepository.markAllPremiumAudiosAsUnlistened(email = email)
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/UpdateAudioItemFavoriteStateUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/UpdateAudioItemFavoriteStateUseCase.kt
@@ -1,18 +1,31 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
 import soy.gabimoreno.domain.repository.premiumaudios.PremiumAudiosRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class UpdateAudioItemFavoriteStateUseCase @Inject constructor(
     private val audioCoursesRepository: AudioCoursesRepository,
+    private val context: Context,
     private val premiumAudioCoursesRepository: PremiumAudiosRepository,
 ) {
     suspend operator fun invoke(idAudioItem: String, markedAsFavorite: Boolean) {
+        val email = context.getEmail().first()
         if (idAudioItem.contains("-")) {
-            audioCoursesRepository.updateMarkedAsFavorite(idAudioItem, markedAsFavorite)
+            audioCoursesRepository.updateMarkedAsFavorite(
+                audioCourseId = idAudioItem,
+                email = email,
+                isFavorite = markedAsFavorite
+            )
         } else {
-            premiumAudioCoursesRepository.markPremiumAudioAsFavorite(idAudioItem, markedAsFavorite)
+            premiumAudioCoursesRepository.markPremiumAudioAsFavorite(
+                email = email,
+                premiumAudioId = idAudioItem,
+                isFavorite = markedAsFavorite
+            )
         }
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/premium/PremiumViewModel.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/premium/PremiumViewModel.kt
@@ -59,7 +59,7 @@ class PremiumViewModel @Inject constructor(
             is PremiumAction.OnListenedToggled -> {
                 viewModelScope.launch(dispatcher) {
                     markPremiumAudioAsListenedUseCase(
-                        idPremiumAudio = action.premiumAudio.id,
+                        premiumAudioId = action.premiumAudio.id,
                         hasBeenListened = !action.premiumAudio.hasBeenListened
                     )
                     val premiumAudioList = state.premiumAudios.map { premiumAudio ->

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/GetAudioCoursesUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/GetAudioCoursesUseCaseTest.kt
@@ -1,9 +1,13 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.left
 import arrow.core.right
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
@@ -12,36 +16,46 @@ import soy.gabimoreno.core.testing.relaxedMockk
 import soy.gabimoreno.data.remote.model.Category
 import soy.gabimoreno.domain.model.content.AudioCourse
 import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
+import soy.gabimoreno.framework.datastore.getEmail
 
 class GetAudioCoursesUseCaseTest {
+
+    private val context = mockk<Context>()
 
     private val repository = mockk<AudioCoursesRepository>()
     private lateinit var useCase: GetAudioCoursesUseCase
 
     @Before
     fun setUp() {
-        useCase = GetAudioCoursesUseCase(repository)
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreEmailKt")
+        every { context.getEmail() } returns flowOf(EMAIL)
+        useCase = GetAudioCoursesUseCase(repository, context)
     }
 
     @Test
     fun `GIVEN repository returns Right WHEN invoked THEN returns list of AudioCourse`() = runTest {
-        val categories = listOf(Category.AUDIOCOURSES)
         val expectedCourses = listOf(relaxedMockk<AudioCourse>())
-        coEvery { repository.getCourses(categories) } returns expectedCourses.right()
+        coEvery {
+            repository.getCourses(categories = CATEGORIES, email = EMAIL, forceRefresh = false)
+        } returns expectedCourses.right()
 
-        val result = useCase(categories)
+        val result = useCase(CATEGORIES)
 
         result shouldBeEqualTo expectedCourses.right()
     }
 
     @Test
     fun `GIVEN repository returns Left WHEN invoked THEN returns error`() = runTest {
-        val categories = listOf(Category.AUDIOCOURSES)
         val error = Throwable("Network error")
-        coEvery { repository.getCourses(categories) } returns error.left()
+        coEvery {
+            repository.getCourses(categories = CATEGORIES, email = EMAIL, forceRefresh = false)
+        } returns error.left()
 
-        val result = useCase(categories)
+        val result = useCase(CATEGORIES)
 
         result shouldBeEqualTo error.left()
     }
 }
+
+private val CATEGORIES = listOf(Category.PREMIUM)
+private const val EMAIL = "test@test.com"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/MarkAudioCourseItemAsListenedUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/MarkAudioCourseItemAsListenedUseCaseTest.kt
@@ -1,5 +1,10 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -7,16 +12,20 @@ import soy.gabimoreno.core.testing.coVerifyOnce
 import soy.gabimoreno.core.testing.relaxedMockk
 import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
 import soy.gabimoreno.fake.buildAudioCourse
+import soy.gabimoreno.framework.datastore.getEmail
 
 class MarkAudioCourseItemAsListenedUseCaseTest {
 
+    private val context: Context = mockk()
     private val repository = relaxedMockk<AudioCoursesRepository>()
 
     private lateinit var useCase: MarkAudioCourseItemAsListenedUseCase
 
     @Before
     fun setUp() {
-        useCase = MarkAudioCourseItemAsListenedUseCase(repository)
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreEmailKt")
+        every { context.getEmail() } returns flowOf(EMAIL)
+        useCase = MarkAudioCourseItemAsListenedUseCase(repository, context)
     }
 
     @Test
@@ -25,7 +34,7 @@ class MarkAudioCourseItemAsListenedUseCaseTest {
         useCase(audioCourse.id, true)
 
         coVerifyOnce {
-            repository.markAudioCourseItemAsListened(audioCourse.id, true)
+            repository.markAudioCourseItemAsListened(audioCourse.id, EMAIL, true)
         }
     }
 
@@ -35,7 +44,9 @@ class MarkAudioCourseItemAsListenedUseCaseTest {
         useCase(audioCourse.id, false)
 
         coVerifyOnce {
-            repository.markAudioCourseItemAsListened(audioCourse.id, false)
+            repository.markAudioCourseItemAsListened(audioCourse.id, EMAIL, false)
         }
     }
 }
+
+private const val EMAIL = "test@test.com"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/MarkPremiumAudioAsListenedUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/MarkPremiumAudioAsListenedUseCaseTest.kt
@@ -1,5 +1,10 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -7,16 +12,20 @@ import soy.gabimoreno.core.testing.coVerifyOnce
 import soy.gabimoreno.core.testing.relaxedMockk
 import soy.gabimoreno.domain.repository.premiumaudios.PremiumAudiosRepository
 import soy.gabimoreno.fake.buildPremiumAudio
+import soy.gabimoreno.framework.datastore.getEmail
 
 class MarkPremiumAudioAsListenedUseCaseTest {
 
+    private val context: Context = mockk()
     private val repository = relaxedMockk<PremiumAudiosRepository>()
 
     private lateinit var useCase: MarkPremiumAudioAsListenedUseCase
 
     @Before
-    fun setUp(){
-        useCase = MarkPremiumAudioAsListenedUseCase(repository)
+    fun setUp() {
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreEmailKt")
+        every { context.getEmail() } returns flowOf(EMAIL)
+        useCase = MarkPremiumAudioAsListenedUseCase(context, repository)
     }
 
     @Test
@@ -25,7 +34,7 @@ class MarkPremiumAudioAsListenedUseCaseTest {
         useCase(premiumAudio.id, true)
 
         coVerifyOnce {
-            repository.markPremiumAudioAsListened(premiumAudio.id, true)
+            repository.markPremiumAudioAsListened(EMAIL, premiumAudio.id, true)
         }
     }
 
@@ -35,7 +44,9 @@ class MarkPremiumAudioAsListenedUseCaseTest {
         useCase(premiumAudio.id, false)
 
         coVerifyOnce {
-            repository.markPremiumAudioAsListened(premiumAudio.id, false)
+            repository.markPremiumAudioAsListened(EMAIL, premiumAudio.id, false)
         }
     }
 }
+
+private const val EMAIL = "test@test.com"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/SetAllAudiocoursesAsUnlistenedUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/SetAllAudiocoursesAsUnlistenedUseCaseTest.kt
@@ -1,35 +1,47 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import soy.gabimoreno.core.testing.coVerifyOnce
 import soy.gabimoreno.core.testing.relaxedMockk
 import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
+import soy.gabimoreno.framework.datastore.getEmail
 
 class SetAllAudiocoursesAsUnlistenedUseCaseTest {
 
     private val audioCoursesRepository: AudioCoursesRepository = relaxedMockk()
+    private val context: Context = mockk()
+
     private lateinit var useCase: SetAllAudiocoursesAsUnlistenedUseCase
 
     @Before
     fun setUp() {
-        useCase = SetAllAudiocoursesAsUnlistenedUseCase(audioCoursesRepository)
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreEmailKt")
+        every { context.getEmail() } returns flowOf(EMAIL)
+        useCase = SetAllAudiocoursesAsUnlistenedUseCase(audioCoursesRepository, context)
     }
 
     @Test
     fun `GIVEN useCase WHEN invoke THEN repository is called`() = runTest {
         coEvery {
-            audioCoursesRepository.markAllAudioCourseItemsAsUnlistened()
+            audioCoursesRepository.markAllAudioCourseItemsAsUnlistened(EMAIL)
         } just Runs
 
         useCase()
 
         coVerifyOnce {
-            audioCoursesRepository.markAllAudioCourseItemsAsUnlistened()
+            audioCoursesRepository.markAllAudioCourseItemsAsUnlistened(EMAIL)
         }
     }
 }
+
+private const val EMAIL = "test@test.com"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/SetAllPremiumAudiosAsUnlistenedUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/SetAllPremiumAudiosAsUnlistenedUseCaseTest.kt
@@ -1,33 +1,46 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import soy.gabimoreno.core.testing.coVerifyOnce
 import soy.gabimoreno.core.testing.relaxedMockk
 import soy.gabimoreno.domain.repository.premiumaudios.PremiumAudiosRepository
+import soy.gabimoreno.framework.datastore.getEmail
 
 
 class SetAllPremiumAudiosAsUnlistenedUseCaseTest {
+
+    private val context: Context = mockk()
     private val premiumAudiosRepository: PremiumAudiosRepository = relaxedMockk()
+
     private lateinit var useCase: SetAllPremiumAudiosAsUnlistenedUseCase
 
     @Before
     fun setUp() {
-        useCase = SetAllPremiumAudiosAsUnlistenedUseCase(premiumAudiosRepository)
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreEmailKt")
+        every { context.getEmail() } returns flowOf(EMAIL)
+        useCase = SetAllPremiumAudiosAsUnlistenedUseCase(context, premiumAudiosRepository)
     }
 
     @Test
     fun `GIVEN useCase WHEN invoke THEN repository is called`() = runTest {
         coEvery {
-            premiumAudiosRepository.markAllPremiumAudiosAsUnlistened()
+            premiumAudiosRepository.markAllPremiumAudiosAsUnlistened(EMAIL)
         } returns Unit
 
         useCase()
 
         coVerifyOnce {
-            premiumAudiosRepository.markAllPremiumAudiosAsUnlistened()
+            premiumAudiosRepository.markAllPremiumAudiosAsUnlistened(EMAIL)
         }
     }
 }
+
+private const val EMAIL = "test@test.com"

--- a/gabimoreno/src/test/java/soy/gabimoreno/fake/FakeCloudAudioSyncable.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/fake/FakeCloudAudioSyncable.kt
@@ -1,0 +1,46 @@
+package soy.gabimoreno.fake
+
+import soy.gabimoreno.data.cloud.audiosync.response.SyncableAudiocourseResponse
+import soy.gabimoreno.data.cloud.audiosync.response.SyncablePremiumAudioResponse
+import soy.gabimoreno.domain.model.content.AudioCourse
+
+fun buildCloudAudiocourseResponseList(hasBeenListened: Boolean = false): List<SyncableAudiocourseResponse> =
+    (1..3).map { index ->
+        buildCloudAudiocourseResponse("1-${index}", hasBeenListened)
+    }
+
+fun buildCloudAudiocourseResponse(id: String, hasBeenListened: Boolean) =
+    SyncableAudiocourseResponse(
+        id = id,
+        hasBeenListened = hasBeenListened,
+        markedAsFavorite = false
+    )
+
+fun buildCloudAudioCourseResponses(
+    remoteCourses: List<AudioCourse>,
+    hasBeenListened: Boolean = false,
+    markedAsFavorite: Boolean = false
+): List<SyncableAudiocourseResponse> {
+    return remoteCourses.flatMap { course ->
+        course.audios.map { audio ->
+            SyncableAudiocourseResponse(
+                id = audio.id,
+                hasBeenListened = hasBeenListened,
+                markedAsFavorite = markedAsFavorite
+            )
+        }
+    }
+}
+
+fun buildCloudPremiumAudiosResponseList(hasBeenListened: Boolean = false): List<SyncablePremiumAudioResponse> =
+    (1..3).map { index ->
+        buildCloudPremiumAudiosResponse(index.toString(), hasBeenListened)
+    }
+
+
+fun buildCloudPremiumAudiosResponse(id: String, hasBeenListened: Boolean) =
+    SyncablePremiumAudioResponse(
+        id = id,
+        hasBeenListened = hasBeenListened,
+        markedAsFavorite = false
+    )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -118,6 +118,7 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 firebase-config = { module = "com.google.firebase:firebase-config-ktx" }
+firebase-firestore = { module = "com.google.firebase:firebase-firestore-ktx" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging-ktx" }
 
 playinapp-review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "play-review" }


### PR DESCRIPTION
### :tophat: How was this resolved?

This commit introduces functionality to synchronize the listened and favorite state of audio courses and premium audios with Firestore.


Key changes include:

- Added `CloudDataSource`, `AudioCoursesCloudDataSource`, and `PremiumAudiosCloudDataSource` to manage Firestore interactions.
- Updated relevant use cases (`MarkPremiumAudioAsListenedUseCase`, `SetAllPremiumAudiosAsUnlistenedUseCase`, etc.) to utilize these data sources and include the user's email for synchronization.
- Modified `PremiumAudiosRemoteMediator` and `DefaultAudioCoursesRepository` to merge remote data with cloud data from Firestore before saving locally.
- Introduced `CloudAudioSyncable` interface and corresponding response models (`CloudAudiocourseResponse`, `CloudPremiumAudiosResponse`) for Firestore data.
- Added new use cases and updated existing ones in `DataStoreModule` to provide context and repositories.
- Updated tests to reflect these changes.