### PR TITLE
Feature: Sync playlist with Firestore

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/mappers/ToPlaylistItemMappers.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/mappers/ToPlaylistItemMappers.kt
@@ -1,0 +1,26 @@
+package soy.gabimoreno.data.cloud.audiosync.mappers
+
+import soy.gabimoreno.data.cloud.playlist.response.CloudPlaylistItemResponse
+import soy.gabimoreno.data.local.playlist.model.PlaylistItemsDbModel
+import soy.gabimoreno.domain.model.content.PlaylistAudioItem
+
+fun CloudPlaylistItemResponse.toPlaylistItemDbModel() = PlaylistItemsDbModel(
+    id = id.toInt(),
+    audioItemId = audioItemId,
+    playlistId = playlistId.toInt(),
+    position = position,
+)
+
+fun PlaylistItemsDbModel.toCloudPlaylistItemResponse() = CloudPlaylistItemResponse(
+    id = id.toString(),
+    audioItemId = audioItemId,
+    playlistId = playlistId.toString(),
+    position = position,
+)
+
+fun PlaylistAudioItem.toCloudPlaylistItemResponse(playlistId: Int) = CloudPlaylistItemResponse(
+    id = playlistItemId.toString(),
+    audioItemId = id,
+    playlistId = playlistId.toString(),
+    position = position,
+)

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/mappers/ToPlaylistMappers.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/mappers/ToPlaylistMappers.kt
@@ -1,0 +1,31 @@
+package soy.gabimoreno.data.cloud.audiosync.mappers
+
+import soy.gabimoreno.data.cloud.playlist.response.CloudPlaylistResponse
+import soy.gabimoreno.data.local.playlist.model.PlaylistDbModel
+import soy.gabimoreno.domain.model.content.Playlist
+import soy.gabimoreno.domain.model.content.PlaylistCategory
+
+fun CloudPlaylistResponse.toPlaylistDbModel() = PlaylistDbModel(
+    id = playlistId.toInt(),
+    categoryId = categoryId,
+    description = description,
+    position = position,
+    title = title,
+)
+
+fun Playlist.toCloudPlaylistResponse() = CloudPlaylistResponse(
+    playlistId = id.toString(),
+    categoryId = category.id,
+    title = title,
+    description = description,
+    position = position,
+)
+
+fun CloudPlaylistResponse.toPlaylist() = Playlist(
+    id = playlistId.toInt(),
+    category = if (categoryId == 1) PlaylistCategory.USER_PLAYLIST else PlaylistCategory.ROADMAP_PLAYLIST,
+    title = title,
+    description = description,
+    position = position,
+    items = emptyList(),
+)

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/response/SyncableAudiocourseResponse.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/response/SyncableAudiocourseResponse.kt
@@ -1,7 +1,9 @@
 package soy.gabimoreno.data.cloud.audiosync.response
 
 data class SyncableAudiocourseResponse(
-    override val id: String = "",
+    override val id: String = EMPTY_STRING,
     override val hasBeenListened: Boolean = false,
     override val markedAsFavorite: Boolean = false
 ) : SyncableAudio
+
+private const val EMPTY_STRING = ""

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/response/SyncablePremiumAudioResponse.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/audiosync/response/SyncablePremiumAudioResponse.kt
@@ -1,7 +1,9 @@
 package soy.gabimoreno.data.cloud.audiosync.response
 
 data class SyncablePremiumAudioResponse(
-    override val id: String = "",
+    override val id: String = EMPTY_STRING,
     override val hasBeenListened: Boolean = false,
     override val markedAsFavorite: Boolean = false,
 ) : SyncableAudio
+
+private const val EMPTY_STRING = ""

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/datasource/CloudPlaylistDataSource.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/datasource/CloudPlaylistDataSource.kt
@@ -20,13 +20,12 @@ class CloudPlaylistDataSource @Inject constructor(
             .toObjects<CloudPlaylistResponse>()
     }
 
-    suspend fun savePlaylist(email: String, playlist: CloudPlaylistResponse) {
+    fun updatePlaylist(email: String, playlist: CloudPlaylistResponse) {
         firestore.collection(USERS_PATH)
             .document(email)
             .collection(PLAYLISTS_PATH)
             .document(playlist.playlistId)
             .set(playlist)
-            .await()
     }
 
     suspend fun deletePlaylist(email: String, playlistId: String) {
@@ -38,6 +37,13 @@ class CloudPlaylistDataSource @Inject constructor(
             .document(playlistId)
             .delete()
             .await()
+    }
+
+    suspend fun deleteAllPlaylists(email: String) {
+        val playlists = getPlaylists(email)
+        playlists.forEach { playlist ->
+            deletePlaylist(email, playlist.playlistId)
+        }
     }
 
     suspend fun getPlaylistItems(
@@ -61,18 +67,18 @@ class CloudPlaylistDataSource @Inject constructor(
             .collection(PLAYLISTS_PATH)
             .document(playlistItem.playlistId)
             .collection(PLAYLIST_ITEMS_PATH)
-            .document(playlistItem.id.toString())
+            .document(playlistItem.id)
             .set(playlistItem)
             .await()
     }
 
-    suspend fun deletePlaylistItem(email: String, playlistId: String, itemId: Int) {
+    suspend fun deletePlaylistItem(email: String, playlistId: String, itemId: String) {
         firestore.collection(USERS_PATH)
             .document(email)
             .collection(PLAYLISTS_PATH)
             .document(playlistId)
             .collection(PLAYLIST_ITEMS_PATH)
-            .document(itemId.toString())
+            .document(itemId)
             .delete()
             .await()
     }

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/response/CloudPlaylistItemResponse.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/response/CloudPlaylistItemResponse.kt
@@ -1,8 +1,11 @@
 package soy.gabimoreno.data.cloud.playlist.response
 
 data class CloudPlaylistItemResponse(
-    val id: Int = -1,
-    val audioItemId: String = "",
-    val playlistId: String = "",
-    val position: Int = -1,
+    val id: String = EMPTY_STRING,
+    val audioItemId: String = EMPTY_STRING,
+    val playlistId: String = EMPTY_STRING,
+    val position: Int = DEFAULT_INT,
 )
+
+private const val EMPTY_STRING = ""
+private const val DEFAULT_INT = -1

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/response/CloudPlaylistResponse.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/cloud/playlist/response/CloudPlaylistResponse.kt
@@ -1,9 +1,12 @@
 package soy.gabimoreno.data.cloud.playlist.response
 
 data class CloudPlaylistResponse(
-    val playlistId: String = "",
-    val categoryId: Int = -1,
-    val description: String = "",
-    val position: Int = -1,
-    val title: String = ""
+    val playlistId: String = EMPTY_STRING,
+    val categoryId: Int = DEFAULT_INT,
+    val description: String = EMPTY_STRING,
+    val position: Int = DEFAULT_INT,
+    val title: String = EMPTY_STRING
 )
+
+private const val EMPTY_STRING = ""
+private const val DEFAULT_INT = -1

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/local/playlist/LocalPlaylistDataSource.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/local/playlist/LocalPlaylistDataSource.kt
@@ -50,6 +50,18 @@ class LocalPlaylistDataSource @Inject constructor(
         playlistDbModelDao.getTotalPlaylists() <= 0
     }
 
+    suspend fun getTotalPlaylistItems(): Int = withContext(dispatcher) {
+        playlistItemDbModelDao.getTotalPlaylistItems()
+    }
+
+    suspend fun getPlaylistItemsCountByPlaylistId(audioItemId: String, playlistId: Int): Int =
+        withContext(dispatcher) {
+            playlistItemDbModelDao.getPlaylistItemIdByAudioItemIdAndPlaylistId(
+                audioItemId,
+                playlistId
+            )
+        }
+
     suspend fun insertPlaylist(name: String, description: String): Playlist =
         withContext(dispatcher) {
             val lastPosition = playlistDbModelDao.getTotalPlaylists()
@@ -116,17 +128,24 @@ class LocalPlaylistDataSource @Inject constructor(
         )
     }
 
+    suspend fun upsertPlaylistItemsDbModel(playlistItems: List<PlaylistItemsDbModel>): List<Long> =
+        withContext(dispatcher) {
+            playlistItemDbModelDao.upsertPlaylistItemsDbModel(playlistItems)
+        }
+
     suspend fun upsertPlaylistItemsDbModel(
         audioId: String,
         playlistIds: List<Int>
     ): List<Long> =
         withContext(dispatcher) {
-            val lastPosition = playlistItemDbModelDao.getTotalPlaylistItems()
+            val startPosition = playlistItemDbModelDao.getTotalPlaylistItems() + 1
             val playlistItems = playlistIds.mapIndexed { index, playlistId ->
+                val position = startPosition + index
                 PlaylistItemsDbModel(
+                    id = position,
                     audioItemId = audioId,
                     playlistId = playlistId,
-                    position = index + lastPosition
+                    position = position
                 )
             }
             playlistItemDbModelDao.upsertPlaylistItemsDbModel(playlistItems)

--- a/gabimoreno/src/main/java/soy/gabimoreno/data/local/playlist/dao/PlaylistItemDbModelDao.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/local/playlist/dao/PlaylistItemDbModelDao.kt
@@ -22,6 +22,9 @@ interface PlaylistItemDbModelDao {
     @Query("SELECT COUNT(*) FROM PlaylistItemsDbModel")
     fun getTotalPlaylistItems(): Int
 
+    @Query("SELECT id FROM PlaylistItemsDbModel WHERE audioItemId = :audioItemId AND playlistId = :playlistId")
+    fun getPlaylistItemIdByAudioItemIdAndPlaylistId(audioItemId: String, playlistId: Int): Int
+
     @Query("DELETE FROM PlaylistItemsDbModel WHERE audioItemId = :audioItemId AND playlistId = :playlistId")
     fun deletePlaylistItemDbModelById(audioItemId: String, playlistId: Int)
 

--- a/gabimoreno/src/main/java/soy/gabimoreno/di/DataStoreModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/DataStoreModule.kt
@@ -7,28 +7,39 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
+import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
 import soy.gabimoreno.domain.repository.premiumaudios.PremiumAudiosRepository
 import soy.gabimoreno.domain.session.MemberSession
 import soy.gabimoreno.domain.usecase.CheckShouldIShowInAppReviewUseCase
+import soy.gabimoreno.domain.usecase.DeleteAllPlaylistUseCase
+import soy.gabimoreno.domain.usecase.DeletePlaylistByIdUseCase
+import soy.gabimoreno.domain.usecase.DeletePlaylistItemByIdUseCase
+import soy.gabimoreno.domain.usecase.GetAllPlaylistUseCase
 import soy.gabimoreno.domain.usecase.GetAudioCoursesUseCase
 import soy.gabimoreno.domain.usecase.GetInAppReviewCounterUseCase
 import soy.gabimoreno.domain.usecase.GetLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase
 import soy.gabimoreno.domain.usecase.GetPremiumAudiosManagedUseCase
 import soy.gabimoreno.domain.usecase.GetShouldIReloadAudioCoursesUseCase
 import soy.gabimoreno.domain.usecase.GetShouldIReversePodcastOrderUseCase
+import soy.gabimoreno.domain.usecase.InsertPlaylistUseCase
 import soy.gabimoreno.domain.usecase.IsBearerTokenValid
 import soy.gabimoreno.domain.usecase.MarkAudioCourseItemAsListenedUseCase
 import soy.gabimoreno.domain.usecase.MarkPremiumAudioAsListenedUseCase
 import soy.gabimoreno.domain.usecase.ResetJwtAuthTokenUseCase
+import soy.gabimoreno.domain.usecase.ResetPlaylistByIdUseCase
 import soy.gabimoreno.domain.usecase.SaveCredentialsInDataStoreUseCase
 import soy.gabimoreno.domain.usecase.SaveLastPremiumAudiosFromRemoteRequestTimeMillisInDataStoreUseCase
+import soy.gabimoreno.domain.usecase.SavePlaylistUseCase
 import soy.gabimoreno.domain.usecase.SetAllAudiocoursesAsUnlistenedUseCase
 import soy.gabimoreno.domain.usecase.SetAllPremiumAudiosAsUnlistenedUseCase
 import soy.gabimoreno.domain.usecase.SetJwtAuthTokenUseCase
+import soy.gabimoreno.domain.usecase.SetPlaylistItemsUseCase
 import soy.gabimoreno.domain.usecase.SetShouldIReloadAudioCoursesUseCase
 import soy.gabimoreno.domain.usecase.SetShouldIReversePodcastOrderUseCase
 import soy.gabimoreno.domain.usecase.SetShouldIShowInAppReviewUseCase
 import soy.gabimoreno.domain.usecase.UpdateAudioItemFavoriteStateUseCase
+import soy.gabimoreno.domain.usecase.UpdatePlaylistItemsUseCase
+import soy.gabimoreno.domain.usecase.UpsertPlaylistsUseCase
 import soy.gabimoreno.framework.datastore.DataStoreMemberSession
 import javax.inject.Singleton
 
@@ -189,5 +200,105 @@ object DataStoreModule {
     ): GetPremiumAudiosManagedUseCase = GetPremiumAudiosManagedUseCase(
         context = context,
         premiumAudiosRepository = premiumAudiosRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideDeleteAllPlaylistUseCase(
+        @ApplicationContext context: Context,
+        playlistRepository: PlaylistRepository
+    ): DeleteAllPlaylistUseCase = DeleteAllPlaylistUseCase(
+        context = context,
+        playlistRepository = playlistRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideDeletePlaylistByIdUseCase(
+        @ApplicationContext context: Context,
+        playlistRepository: PlaylistRepository
+    ): DeletePlaylistByIdUseCase = DeletePlaylistByIdUseCase(
+        context = context,
+        playlistRepository = playlistRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideDeletePlaylistItemByIdUseCase(
+        @ApplicationContext context: Context,
+        playlistRepository: PlaylistRepository
+    ): DeletePlaylistItemByIdUseCase = DeletePlaylistItemByIdUseCase(
+        context = context,
+        playlistRepository = playlistRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideGetAllPlaylistUseCase(
+        @ApplicationContext context: Context,
+        playlistRepository: PlaylistRepository
+    ): GetAllPlaylistUseCase = GetAllPlaylistUseCase(
+        context = context,
+        playlistRepository = playlistRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideResetPlaylistByIdUseCase(
+        @ApplicationContext context: Context,
+        playlistRepository: PlaylistRepository
+    ): ResetPlaylistByIdUseCase = ResetPlaylistByIdUseCase(
+        context = context,
+        playlistRepository = playlistRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideSavePlaylistUseCase(
+        @ApplicationContext context: Context,
+        playlistRepository: PlaylistRepository
+    ): SavePlaylistUseCase = SavePlaylistUseCase(
+        context = context,
+        playlistRepository = playlistRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideSetPlaylistItemsUseCase(
+        @ApplicationContext context: Context,
+        playlistRepository: PlaylistRepository
+    ): SetPlaylistItemsUseCase = SetPlaylistItemsUseCase(
+        context = context,
+        repository = playlistRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideUpdatePlaylistItemsUseCase(
+        @ApplicationContext context: Context,
+        playlistRepository: PlaylistRepository
+    ): UpdatePlaylistItemsUseCase = UpdatePlaylistItemsUseCase(
+        context = context,
+        repository = playlistRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideUpsertPlaylistsUseCase(
+        @ApplicationContext context: Context,
+        playlistRepository: PlaylistRepository
+    ): UpsertPlaylistsUseCase = UpsertPlaylistsUseCase(
+        context = context,
+        repository = playlistRepository
+    )
+
+    @Provides
+    @Singleton
+    fun provideInsertPlaylistUseCase(
+        @ApplicationContext context: Context,
+        playlistRepository: PlaylistRepository
+    ): InsertPlaylistUseCase = InsertPlaylistUseCase(
+        context = context,
+        playlistRepository = playlistRepository
     )
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/di/data/RepositoryModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/data/RepositoryModule.kt
@@ -6,6 +6,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import soy.gabimoreno.data.cloud.audiosync.datasource.AudioCoursesCloudDataSource
 import soy.gabimoreno.data.cloud.audiosync.datasource.PremiumAudiosCloudDataSource
+import soy.gabimoreno.data.cloud.playlist.datasource.CloudPlaylistDataSource
 import soy.gabimoreno.data.local.audiocourse.LocalAudioCoursesDataSource
 import soy.gabimoreno.data.local.playlist.LocalPlaylistDataSource
 import soy.gabimoreno.data.local.premiumaudio.LocalPremiumAudiosDataSource
@@ -80,8 +81,10 @@ object RepositoryModule {
     @Provides
     @Singleton
     fun providePlaylistRepository(
+        cloudDataSource: CloudPlaylistDataSource,
         localPlaylistDataSource: LocalPlaylistDataSource,
     ): PlaylistRepository = DefaultPlaylistRepository(
+        cloudDataSource,
         localPlaylistDataSource
     )
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/playlist/DefaultPlaylistRepository.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/playlist/DefaultPlaylistRepository.kt
@@ -2,6 +2,12 @@ package soy.gabimoreno.domain.repository.playlist
 
 import arrow.core.Either
 import kotlinx.coroutines.flow.first
+import soy.gabimoreno.data.cloud.audiosync.mappers.toCloudPlaylistItemResponse
+import soy.gabimoreno.data.cloud.audiosync.mappers.toCloudPlaylistResponse
+import soy.gabimoreno.data.cloud.audiosync.mappers.toPlaylist
+import soy.gabimoreno.data.cloud.audiosync.mappers.toPlaylistItemDbModel
+import soy.gabimoreno.data.cloud.playlist.datasource.CloudPlaylistDataSource
+import soy.gabimoreno.data.cloud.playlist.response.CloudPlaylistItemResponse
 import soy.gabimoreno.data.local.mapper.toPlaylistItemDbModel
 import soy.gabimoreno.data.local.playlist.LocalPlaylistDataSource
 import soy.gabimoreno.domain.model.content.Playlist
@@ -11,6 +17,7 @@ import javax.inject.Singleton
 
 @Singleton
 class DefaultPlaylistRepository @Inject constructor(
+    private val cloudPlaylistDataSource: CloudPlaylistDataSource,
     private val localPlaylistDataSource: LocalPlaylistDataSource,
 ) : PlaylistRepository {
     override suspend fun isEmpty(): Either<Throwable, Boolean> {
@@ -19,16 +26,43 @@ class DefaultPlaylistRepository @Inject constructor(
 
     override suspend fun insertPlaylist(
         name: String,
-        description: String
+        description: String,
+        email: String,
     ): Either<Throwable, Playlist> {
-        return localPlaylistDataSource.insertPlaylist(name, description).let { Either.Right(it) }
+        val playlist = localPlaylistDataSource.insertPlaylist(name, description)
+        if (email.isNotEmpty()) {
+            cloudPlaylistDataSource.updatePlaylist(
+                email = email,
+                playlist = playlist.toCloudPlaylistResponse()
+            )
+        }
+        return Either.Right(playlist)
     }
 
-    override suspend fun savePlaylist(playlist: Playlist): Either<Throwable, Unit> {
-        return localPlaylistDataSource.savePlaylist(listOf(playlist)).let { Either.Right(Unit) }
+    override suspend fun savePlaylist(playlist: Playlist, email: String): Either<Throwable, Unit> {
+        if (email.isNotEmpty()) {
+            cloudPlaylistDataSource.updatePlaylist(
+                email = email,
+                playlist = playlist.toCloudPlaylistResponse()
+            )
+        }
+        return localPlaylistDataSource
+            .savePlaylist(listOf(playlist))
+            .let { Either.Right(Unit) }
     }
 
-    override suspend fun getAllPlaylists(): Either<Throwable, List<Playlist>> {
+    override suspend fun getAllPlaylists(email: String): Either<Throwable, List<Playlist>> {
+        if (email.isNotEmpty()) {
+            val playlists = cloudPlaylistDataSource.getPlaylists(email)
+            localPlaylistDataSource.upsertPlaylistDbModels(playlists.map { it.toPlaylist() })
+            playlists.forEach { playlist ->
+                val audioItems =
+                    cloudPlaylistDataSource.getPlaylistItems(email, playlist.playlistId)
+                localPlaylistDataSource.upsertPlaylistItemsDbModel(audioItems.map {
+                    it.toPlaylistItemDbModel()
+                })
+            }
+        }
         return localPlaylistDataSource.getAllPlaylists().let { Either.Right(it) }
     }
 
@@ -41,46 +75,113 @@ class DefaultPlaylistRepository @Inject constructor(
             .let { Either.Right(it) }
     }
 
-    override suspend fun upsertPlaylists(playlists: List<Playlist>): Either<Throwable, Unit> {
+    override suspend fun upsertPlaylists(
+        playlists: List<Playlist>,
+        email: String
+    ): Either<Throwable, Unit> {
+        if (email.isNotEmpty()) {
+            playlists.forEach { playlist ->
+                cloudPlaylistDataSource.updatePlaylist(
+                    email = email,
+                    playlist = playlist.toCloudPlaylistResponse()
+                )
+            }
+        }
         return localPlaylistDataSource.upsertPlaylistDbModels(playlists)
             .let { Either.Right(Unit) }
     }
 
     override suspend fun upsertPlaylistItems(
         audioId: String,
-        playlistIds: List<Int>
+        playlistIds: List<Int>,
+        email: String,
     ): Either<Throwable, List<Long>> {
-        return localPlaylistDataSource.upsertPlaylistItemsDbModel(audioId, playlistIds)
-            .let { Either.Right(it) }
+        val result = localPlaylistDataSource.upsertPlaylistItemsDbModel(audioId, playlistIds)
+
+        if (email.isNotEmpty()) {
+            val startPosition =
+                localPlaylistDataSource.getTotalPlaylistItems() - playlistIds.size + 1
+
+            playlistIds.forEachIndexed { index, playlistId ->
+                val position = startPosition + index
+                cloudPlaylistDataSource.savePlaylistItem(
+                    email = email,
+                    playlistItem = CloudPlaylistItemResponse(
+                        id = position.toString(),
+                        audioItemId = audioId,
+                        playlistId = playlistId.toString(),
+                        position = position
+                    )
+                )
+            }
+        }
+
+        return Either.Right(result)
     }
 
     override suspend fun updatePlaylistItems(
         playlistId: Int,
-        playlistItems: List<PlaylistAudioItem>
+        playlistItems: List<PlaylistAudioItem>,
+        email: String,
     ): Either<Throwable, Unit> {
+        if (email.isNotEmpty()) {
+            playlistItems.forEachIndexed { index, playlistAudioItem ->
+                cloudPlaylistDataSource.savePlaylistItem(
+                    email = email,
+                    playlistItem = playlistAudioItem.toCloudPlaylistItemResponse(playlistId)
+                )
+            }
+        }
         val playlistItemsDbModel = playlistItems.map { it.toPlaylistItemDbModel(playlistId) }
         return localPlaylistDataSource.updatePlaylistItems(playlistItemsDbModel)
             .let { Either.Right(Unit) }
     }
 
-    override suspend fun resetPlaylistById(idPlaylist: Int): Either<Throwable, Unit> {
+    override suspend fun resetPlaylistById(
+        idPlaylist: Int,
+        email: String
+    ): Either<Throwable, Unit> {
         return localPlaylistDataSource.resetPlaylistById(idPlaylist).let { Either.Right(Unit) }
     }
 
     override suspend fun deletePlaylistItemById(
         audioItemId: String,
-        playlistId: Int
+        playlistId: Int,
+        email: String,
     ): Either<Throwable, Unit> {
+        if (email.isNotEmpty()) {
+            val itemToDelete = localPlaylistDataSource.getPlaylistItemsCountByPlaylistId(
+                audioItemId,
+                playlistId
+            )
+            cloudPlaylistDataSource.deletePlaylistItem(
+                email = email,
+                playlistId = playlistId.toString(),
+                itemId = itemToDelete.toString()
+            )
+        }
         return localPlaylistDataSource.deletePlaylistItemDbModelById(audioItemId, playlistId)
             .let { Either.Right(Unit) }
     }
 
-    override suspend fun deletePlaylistById(playlistId: Int): Either<Throwable, Unit> {
+    override suspend fun deletePlaylistById(
+        playlistId: Int,
+        email: String
+    ): Either<Throwable, Unit> {
+        if (email.isNotEmpty()) {
+            cloudPlaylistDataSource.deletePlaylist(
+                email = email,
+                playlistId = playlistId.toString()
+            )
+        }
         return localPlaylistDataSource.deletePlaylistDbModelById(playlistId)
             .let { Either.Right(Unit) }
     }
 
-    override suspend fun deleteAllPlaylists(): Either<Throwable, Unit> {
+    override suspend fun deleteAllPlaylists(email: String): Either<Throwable, Unit> {
+        if (email.isNotEmpty()) {
+            cloudPlaylistDataSource.deleteAllPlaylists(email)
+        }
         return localPlaylistDataSource.deleteAllPlaylists().let { Either.Right(Unit) }
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/playlist/PlaylistRepository.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/playlist/PlaylistRepository.kt
@@ -6,25 +6,36 @@ import soy.gabimoreno.domain.model.content.PlaylistAudioItem
 
 interface PlaylistRepository {
     suspend fun isEmpty(): Either<Throwable, Boolean>
-    suspend fun insertPlaylist(name: String, description: String): Either<Throwable, Playlist>
-    suspend fun savePlaylist(playlist: Playlist): Either<Throwable, Unit>
-    suspend fun getAllPlaylists(): Either<Throwable, List<Playlist>>
+    suspend fun insertPlaylist(
+        name: String,
+        description: String,
+        email: String
+    ): Either<Throwable, Playlist>
+
+    suspend fun savePlaylist(playlist: Playlist, email: String): Either<Throwable, Unit>
+    suspend fun getAllPlaylists(email: String): Either<Throwable, List<Playlist>>
     suspend fun getPlaylistById(idPlaylist: Int): Either<Throwable, Playlist?>
     suspend fun getPlaylistIdsByItemId(audioItemId: String): Either<Throwable, List<Int>>
-    suspend fun upsertPlaylists(playlists: List<Playlist>): Either<Throwable, Unit>
+    suspend fun upsertPlaylists(playlists: List<Playlist>, email: String): Either<Throwable, Unit>
     suspend fun upsertPlaylistItems(
         audioId: String,
-        playlistIds: List<Int>
+        playlistIds: List<Int>,
+        email: String,
     ): Either<Throwable, List<Long>>
+
     suspend fun updatePlaylistItems(
         playlistId: Int,
-        playlistItems: List<PlaylistAudioItem>
+        playlistItems: List<PlaylistAudioItem>,
+        email: String,
     ): Either<Throwable, Unit>
-    suspend fun resetPlaylistById(idPlaylist: Int): Either<Throwable, Unit>
+
+    suspend fun resetPlaylistById(idPlaylist: Int, email: String): Either<Throwable, Unit>
     suspend fun deletePlaylistItemById(
         audioItemId: String,
-        playlistId: Int
+        playlistId: Int,
+        email: String,
     ): Either<Throwable, Unit>
-    suspend fun deletePlaylistById(playlistId: Int): Either<Throwable, Unit>
-    suspend fun deleteAllPlaylists(): Either<Throwable, Unit>
+
+    suspend fun deletePlaylistById(playlistId: Int, email: String): Either<Throwable, Unit>
+    suspend fun deleteAllPlaylists(email: String): Either<Throwable, Unit>
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/DeleteAllPlaylistUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/DeleteAllPlaylistUseCase.kt
@@ -1,13 +1,18 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class DeleteAllPlaylistUseCase @Inject constructor(
+    private val context: Context,
     private val playlistRepository: PlaylistRepository
 ) {
     suspend operator fun invoke(): Either<Throwable, Unit> {
-        return playlistRepository.deleteAllPlaylists()
+        val email = context.getEmail().first()
+        return playlistRepository.deleteAllPlaylists(email)
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/DeletePlaylistByIdUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/DeletePlaylistByIdUseCase.kt
@@ -1,13 +1,18 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class DeletePlaylistByIdUseCase @Inject constructor(
+    private val context: Context,
     private val playlistRepository: PlaylistRepository
 ) {
     suspend operator fun invoke(playlistId: Int): Either<Throwable, Unit> {
-        return playlistRepository.deletePlaylistById(playlistId)
+        val email = context.getEmail().first()
+        return playlistRepository.deletePlaylistById(playlistId, email)
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/DeletePlaylistItemByIdUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/DeletePlaylistItemByIdUseCase.kt
@@ -1,13 +1,18 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class DeletePlaylistItemByIdUseCase @Inject constructor(
+    private val context: Context,
     private val playlistRepository: PlaylistRepository
 ) {
     suspend operator fun invoke(audioItemId: String, playlistId: Int): Either<Throwable, Unit> {
-        return playlistRepository.deletePlaylistItemById(audioItemId, playlistId)
+        val email = context.getEmail().first()
+        return playlistRepository.deletePlaylistItemById(audioItemId, playlistId, email)
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetAllPlaylistUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetAllPlaylistUseCase.kt
@@ -1,14 +1,19 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.model.content.Playlist
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class GetAllPlaylistUseCase @Inject constructor(
+    private val context: Context,
     private val playlistRepository: PlaylistRepository
 ) {
     suspend operator fun invoke(): Either<Throwable, List<Playlist>> {
-        return playlistRepository.getAllPlaylists()
+        val email = context.getEmail().first()
+        return playlistRepository.getAllPlaylists(email)
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/InsertPlaylistUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/InsertPlaylistUseCase.kt
@@ -1,14 +1,23 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.model.content.Playlist
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class InsertPlaylistUseCase @Inject constructor(
+    private val context: Context,
     private val playlistRepository: PlaylistRepository
 ) {
     suspend operator fun invoke(name: String, description: String): Either<Throwable, Playlist> {
-        return playlistRepository.insertPlaylist(name = name, description = description)
+        val email = context.getEmail().first()
+        return playlistRepository.insertPlaylist(
+            name = name,
+            description = description,
+            email = email
+        )
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/ResetPlaylistByIdUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/ResetPlaylistByIdUseCase.kt
@@ -1,13 +1,18 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class ResetPlaylistByIdUseCase @Inject constructor(
+    private val context: Context,
     private val playlistRepository: PlaylistRepository
 ) {
     suspend operator fun invoke(idPlaylist: Int): Either<Throwable, Unit> {
-        return playlistRepository.resetPlaylistById(idPlaylist)
+        val email = context.getEmail().first()
+        return playlistRepository.resetPlaylistById(idPlaylist, email)
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SavePlaylistUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SavePlaylistUseCase.kt
@@ -1,14 +1,19 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.model.content.Playlist
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class SavePlaylistUseCase @Inject constructor(
+    private val context: Context,
     private val playlistRepository: PlaylistRepository
 ) {
     suspend operator fun invoke(playlist: Playlist): Either<Throwable, Unit> {
-        return playlistRepository.savePlaylist(playlist)
+        val email = context.getEmail().first()
+        return playlistRepository.savePlaylist(playlist, email)
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetPlaylistItemsUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetPlaylistItemsUseCase.kt
@@ -1,16 +1,21 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class SetPlaylistItemsUseCase @Inject constructor(
+    private val context: Context,
     private val repository: PlaylistRepository
 ) {
     suspend operator fun invoke(
         audioId: String,
         playlistIds: List<Int>
     ): Either<Throwable, List<Long>> {
-        return repository.upsertPlaylistItems(audioId, playlistIds)
+        val email = context.getEmail().first()
+        return repository.upsertPlaylistItems(audioId, playlistIds, email)
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/UpdatePlaylistItemsUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/UpdatePlaylistItemsUseCase.kt
@@ -1,20 +1,26 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.model.content.PlaylistAudioItem
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class UpdatePlaylistItemsUseCase @Inject constructor(
+    private val context: Context,
     private val repository: PlaylistRepository
 ) {
     suspend operator fun invoke(
         playlistId: Int,
         playlistItems: List<PlaylistAudioItem>
     ): Either<Throwable, Unit> {
+        val email = context.getEmail().first()
         return repository.updatePlaylistItems(
             playlistId = playlistId,
-            playlistItems = playlistItems
+            playlistItems = playlistItems,
+            email = email
         )
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/UpsertPlaylistsUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/UpsertPlaylistsUseCase.kt
@@ -1,16 +1,21 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
+import kotlinx.coroutines.flow.first
 import soy.gabimoreno.domain.model.content.Playlist
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 import javax.inject.Inject
 
 class UpsertPlaylistsUseCase @Inject constructor(
+    private val context: Context,
     private val repository: PlaylistRepository
 ) {
     suspend operator fun invoke(
         playlists: List<Playlist>
     ): Either<Throwable, Unit> {
-        return repository.upsertPlaylists(playlists)
+        val email = context.getEmail().first()
+        return repository.upsertPlaylists(playlists, email)
     }
 }

--- a/gabimoreno/src/test/java/soy/gabimoreno/data/local/playlist/LocalPlaylistDataSourceTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/data/local/playlist/LocalPlaylistDataSourceTest.kt
@@ -198,20 +198,19 @@ class LocalPlaylistDataSourceTest {
     @Test
     fun `GIVEN playlistIds WHEN upsertPlaylistItemsDbModel THEN upserts items with correct positions`() =
         runTest {
-            val playlistItemId = "audio-123"
+            val audioId = "audio-123"
             val playlistIds = listOf(1, 2, 3)
-            val lastPosition = 5
+            val lastPosition = 4
             val expectedItems = listOf(
-                PlaylistItemsDbModel(audioItemId = playlistItemId, playlistId = 1, position = 5),
-                PlaylistItemsDbModel(audioItemId = playlistItemId, playlistId = 2, position = 6),
-                PlaylistItemsDbModel(audioItemId = playlistItemId, playlistId = 3, position = 7)
+                PlaylistItemsDbModel(id = 5, audioItemId = audioId, playlistId = 1, position = 5),
+                PlaylistItemsDbModel(id = 6, audioItemId = audioId, playlistId = 2, position = 6),
+                PlaylistItemsDbModel(id = 7, audioItemId = audioId, playlistId = 3, position = 7)
             )
-            val expectedResult: List<Long> = listOf(1001, 1002, 1003)
-
+            val expectedResult = listOf(1001L, 1002L, 1003L)
             coEvery { playlistItemDbModelDao.getTotalPlaylistItems() } returns lastPosition
             coEvery { playlistItemDbModelDao.upsertPlaylistItemsDbModel(expectedItems) } returns expectedResult
 
-            val result = playlistDataSource.upsertPlaylistItemsDbModel(playlistItemId, playlistIds)
+            val result = playlistDataSource.upsertPlaylistItemsDbModel(audioId, playlistIds)
 
             result shouldBeEqualTo expectedResult
             coVerifyOnce {

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/DeleteAllPlaylistUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/DeleteAllPlaylistUseCaseTest.kt
@@ -1,7 +1,12 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
 import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
@@ -10,20 +15,25 @@ import org.junit.Test
 import soy.gabimoreno.core.testing.coVerifyOnce
 import soy.gabimoreno.core.testing.relaxedMockk
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 
 class DeleteAllPlaylistUseCaseTest {
 
+    private val context: Context = mockk()
     private val playlistRepository: PlaylistRepository = relaxedMockk()
+
     private lateinit var useCase: DeleteAllPlaylistUseCase
 
     @Before
     fun setUp() {
-        useCase = DeleteAllPlaylistUseCase(playlistRepository)
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreEmailKt")
+        every { context.getEmail() } returns flowOf(EMAIL)
+        useCase = DeleteAllPlaylistUseCase(context, playlistRepository)
     }
 
     @Test
     fun `GIVEN repository returns Right WHEN invoke THEN returns Right with Unit`() = runTest {
-        coEvery { playlistRepository.deleteAllPlaylists() } returns Either.Right(Unit)
+        coEvery { playlistRepository.deleteAllPlaylists(EMAIL) } returns Either.Right(Unit)
 
         val result = useCase()
 
@@ -34,7 +44,7 @@ class DeleteAllPlaylistUseCaseTest {
     @Test
     fun `GIVEN repository returns Left WHEN invoke THEN returns Left with exception`() = runTest {
         val exception = RuntimeException("Database error")
-        coEvery { playlistRepository.deleteAllPlaylists() } returns Either.Left(exception)
+        coEvery { playlistRepository.deleteAllPlaylists(EMAIL) } returns Either.Left(exception)
 
         val result = useCase()
 
@@ -44,12 +54,14 @@ class DeleteAllPlaylistUseCaseTest {
 
     @Test
     fun `GIVEN repository WHEN invoke THEN deleteAllPlaylists is called`() = runTest {
-        coEvery { playlistRepository.deleteAllPlaylists() } returns Either.Right(Unit)
+        coEvery { playlistRepository.deleteAllPlaylists(EMAIL) } returns Either.Right(Unit)
 
         useCase()
 
         coVerifyOnce {
-            playlistRepository.deleteAllPlaylists()
+            playlistRepository.deleteAllPlaylists(EMAIL)
         }
     }
 }
+
+private const val EMAIL = "test@test.com"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/GetAllPlaylistUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/GetAllPlaylistUseCaseTest.kt
@@ -1,7 +1,12 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
 import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
@@ -12,22 +17,27 @@ import soy.gabimoreno.core.testing.relaxedMockk
 import soy.gabimoreno.domain.model.content.Playlist
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
 import soy.gabimoreno.fake.buildPlaylist
+import soy.gabimoreno.framework.datastore.getEmail
 
 class GetAllPlaylistUseCaseTest {
 
+    private val context: Context = mockk()
     private val playlistRepository: PlaylistRepository = relaxedMockk()
+
     private lateinit var useCase: GetAllPlaylistUseCase
 
     @Before
     fun setUp() {
-        useCase = GetAllPlaylistUseCase(playlistRepository)
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreEmailKt")
+        every { context.getEmail() } returns flowOf(EMAIL)
+        useCase = GetAllPlaylistUseCase(context, playlistRepository)
     }
 
     @Test
     fun `GIVEN repository returns Right with playlists WHEN invoke THEN returns Right with playlists`() =
         runTest {
             val playlists = listOf(buildPlaylist())
-            coEvery { playlistRepository.getAllPlaylists() } returns Either.Right(playlists)
+            coEvery { playlistRepository.getAllPlaylists(EMAIL) } returns Either.Right(playlists)
 
             val result = useCase()
 
@@ -39,7 +49,9 @@ class GetAllPlaylistUseCaseTest {
     fun `GIVEN repository returns Right with empty list WHEN invoke THEN returns Right with empty list`() =
         runTest {
             val emptyPlaylists = emptyList<Playlist>()
-            coEvery { playlistRepository.getAllPlaylists() } returns Either.Right(emptyPlaylists)
+            coEvery { playlistRepository.getAllPlaylists(EMAIL) } returns Either.Right(
+                emptyPlaylists
+            )
 
             val result = useCase()
 
@@ -50,7 +62,7 @@ class GetAllPlaylistUseCaseTest {
     @Test
     fun `GIVEN repository returns Left WHEN invoke THEN returns Left with exception`() = runTest {
         val exception = RuntimeException("Database error")
-        coEvery { playlistRepository.getAllPlaylists() } returns Either.Left(exception)
+        coEvery { playlistRepository.getAllPlaylists(EMAIL) } returns Either.Left(exception)
 
         val result = useCase()
 
@@ -60,12 +72,14 @@ class GetAllPlaylistUseCaseTest {
 
     @Test
     fun `GIVEN repository WHEN invoke THEN getAllPlaylists is called`() = runTest {
-        coEvery { playlistRepository.getAllPlaylists() } returns Either.Right(emptyList())
+        coEvery { playlistRepository.getAllPlaylists(EMAIL) } returns Either.Right(emptyList())
 
         useCase()
 
         coVerifyOnce {
-            playlistRepository.getAllPlaylists()
+            playlistRepository.getAllPlaylists(EMAIL)
         }
     }
 }
+
+private const val EMAIL = "test@test.com"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/InsertPlaylistUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/InsertPlaylistUseCaseTest.kt
@@ -1,9 +1,13 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.left
 import arrow.core.right
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
@@ -11,15 +15,20 @@ import org.junit.Test
 import soy.gabimoreno.core.testing.coVerifyOnce
 import soy.gabimoreno.domain.model.content.Playlist
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 
 class InsertPlaylistUseCaseTest {
 
+    private val context: Context = mockk()
     private val playlistRepository = mockk<PlaylistRepository>()
+
     private lateinit var useCase: InsertPlaylistUseCase
 
     @Before
     fun setUp() {
-        useCase = InsertPlaylistUseCase(playlistRepository)
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreEmailKt")
+        every { context.getEmail() } returns flowOf(EMAIL)
+        useCase = InsertPlaylistUseCase(context, playlistRepository)
     }
 
     @Test
@@ -35,14 +44,14 @@ class InsertPlaylistUseCaseTest {
                 position = 0
             )
             coEvery {
-                playlistRepository.insertPlaylist(name, description)
+                playlistRepository.insertPlaylist(name, description, EMAIL)
             } returns playList.right()
 
             val result = useCase(name, description)
 
             result shouldBeEqualTo playList.right()
             coVerifyOnce {
-                playlistRepository.insertPlaylist(name, description)
+                playlistRepository.insertPlaylist(name, description, EMAIL)
             }
         }
 
@@ -53,14 +62,16 @@ class InsertPlaylistUseCaseTest {
             val description = "Playlist Description"
             val exception: Throwable = RuntimeException("Database error")
             coEvery {
-                playlistRepository.insertPlaylist(name, description)
+                playlistRepository.insertPlaylist(name, description, EMAIL)
             } returns exception.left()
 
             val result = useCase(name, description)
 
             result shouldBeEqualTo exception.left()
             coVerifyOnce {
-                playlistRepository.insertPlaylist(name, description)
+                playlistRepository.insertPlaylist(name, description, EMAIL)
             }
         }
 }
+
+private const val EMAIL = "test@test.com"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/ResetPlaylistByIdUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/ResetPlaylistByIdUseCaseTest.kt
@@ -1,36 +1,45 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
 import org.junit.Test
 import soy.gabimoreno.core.testing.coVerifyOnce
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 
 class ResetPlaylistByIdUseCaseTest {
 
+    private val context: Context = mockk()
     private val playlistRepository = mockk<PlaylistRepository>()
+
     private lateinit var useCase: ResetPlaylistByIdUseCase
 
     @Before
     fun setUp() {
-        useCase = ResetPlaylistByIdUseCase(playlistRepository)
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreEmailKt")
+        every { context.getEmail() } returns flowOf(EMAIL)
+        useCase = ResetPlaylistByIdUseCase(context, playlistRepository)
     }
 
     @Test
     fun `GIVEN valid playlist id WHEN invoke THEN returns right with unit`() = runTest {
         val playlistId = 123
         val expectedEither = Either.Right(Unit)
-        coEvery { playlistRepository.resetPlaylistById(playlistId) } returns expectedEither
+        coEvery { playlistRepository.resetPlaylistById(playlistId, EMAIL) } returns expectedEither
 
         val result = useCase(playlistId)
 
         result shouldBeEqualTo expectedEither
         coVerifyOnce {
-            playlistRepository.resetPlaylistById(playlistId)
+            playlistRepository.resetPlaylistById(playlistId, EMAIL)
         }
     }
 
@@ -40,13 +49,18 @@ class ResetPlaylistByIdUseCaseTest {
             val playlistId = 123
             val exception = RuntimeException("Reset failed")
             val expectedEither = Either.Left(exception)
-            coEvery { playlistRepository.resetPlaylistById(playlistId) } returns expectedEither
+            coEvery {
+                playlistRepository.resetPlaylistById(
+                    playlistId,
+                    EMAIL
+                )
+            } returns expectedEither
 
             val result = useCase(playlistId)
 
             result shouldBeEqualTo expectedEither
             coVerifyOnce {
-                playlistRepository.resetPlaylistById(playlistId)
+                playlistRepository.resetPlaylistById(playlistId, EMAIL)
             }
         }
 
@@ -54,13 +68,15 @@ class ResetPlaylistByIdUseCaseTest {
     fun `GIVEN empty playlist id WHEN invoke THEN delegates to repository`() = runTest {
         val playlistId = -1
         val expectedEither = Either.Right(Unit)
-        coEvery { playlistRepository.resetPlaylistById(playlistId) } returns expectedEither
+        coEvery { playlistRepository.resetPlaylistById(playlistId, EMAIL) } returns expectedEither
 
         val result = useCase(playlistId)
 
         result shouldBeEqualTo expectedEither
         coVerifyOnce {
-            playlistRepository.resetPlaylistById(playlistId)
+            playlistRepository.resetPlaylistById(playlistId, EMAIL)
         }
     }
 }
+
+private const val EMAIL = "test@test.com"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/SavePlaylistUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/SavePlaylistUseCaseTest.kt
@@ -1,8 +1,12 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import arrow.core.Either
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
@@ -10,28 +14,33 @@ import org.junit.Test
 import soy.gabimoreno.core.testing.coVerifyOnce
 import soy.gabimoreno.domain.model.content.Playlist
 import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
+import soy.gabimoreno.framework.datastore.getEmail
 
 class SavePlaylistUseCaseTest {
 
+    private val context: Context = mockk()
     private val playlistRepository = mockk<PlaylistRepository>()
+
     private lateinit var useCase: SavePlaylistUseCase
 
     @Before
     fun setUp() {
-        useCase = SavePlaylistUseCase(playlistRepository)
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreEmailKt")
+        every { context.getEmail() } returns flowOf(EMAIL)
+        useCase = SavePlaylistUseCase(context, playlistRepository)
     }
 
     @Test
     fun `GIVEN valid playlist WHEN invoke THEN returns right with unit`() = runTest {
         val playlist = mockk<Playlist>()
         val expectedEither = Either.Right(Unit)
-        coEvery { playlistRepository.savePlaylist(playlist) } returns expectedEither
+        coEvery { playlistRepository.savePlaylist(playlist, EMAIL) } returns expectedEither
 
         val result = useCase(playlist)
 
         result shouldBeEqualTo expectedEither
         coVerifyOnce {
-            playlistRepository.savePlaylist(playlist)
+            playlistRepository.savePlaylist(playlist, EMAIL)
         }
     }
 
@@ -41,13 +50,15 @@ class SavePlaylistUseCaseTest {
             val playlist = mockk<Playlist>()
             val exception = RuntimeException("Save failed")
             val expectedEither = Either.Left(exception)
-            coEvery { playlistRepository.savePlaylist(playlist) } returns expectedEither
+            coEvery { playlistRepository.savePlaylist(playlist, EMAIL) } returns expectedEither
 
             val result = useCase(playlist)
 
             result shouldBeEqualTo expectedEither
             coVerifyOnce {
-                playlistRepository.savePlaylist(playlist)
+                playlistRepository.savePlaylist(playlist, EMAIL)
             }
         }
 }
+
+private const val EMAIL = "test@test.com"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/UpsertPlaylistsUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/UpsertPlaylistsUseCaseTest.kt
@@ -1,7 +1,11 @@
 package soy.gabimoreno.domain.usecase
 
+import android.content.Context
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
@@ -11,27 +15,32 @@ import soy.gabimoreno.domain.repository.playlist.PlaylistRepository
 import soy.gabimoreno.ext.left
 import soy.gabimoreno.ext.right
 import soy.gabimoreno.fake.buildPlaylist
+import soy.gabimoreno.framework.datastore.getEmail
 
 class UpsertPlaylistsUseCaseTest {
 
+    private val context: Context = mockk()
     private val repository = mockk<PlaylistRepository>()
+
     private lateinit var useCase: UpsertPlaylistsUseCase
 
     @Before
     fun setUp() {
-        useCase = UpsertPlaylistsUseCase(repository)
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreEmailKt")
+        every { context.getEmail() } returns flowOf(EMAIL)
+        useCase = UpsertPlaylistsUseCase(context, repository)
     }
 
     @Test
     fun `GIVEN valid list of playlist WHEN invoke THEN Right unit is returned`() = runTest {
         val playlists = listOf(buildPlaylist(), buildPlaylist(2))
-        coEvery { repository.upsertPlaylists(playlists) } returns right(Unit)
+        coEvery { repository.upsertPlaylists(playlists, EMAIL) } returns right(Unit)
 
         val result = useCase(playlists)
 
         result shouldBeEqualTo right(Unit)
         coVerifyOnce {
-            repository.upsertPlaylists(playlists)
+            repository.upsertPlaylists(playlists, EMAIL)
         }
     }
 
@@ -39,7 +48,7 @@ class UpsertPlaylistsUseCaseTest {
     fun `GIVEN repository fails WHEN invoke THEN Left with throwable is returned`() = runTest {
         val playlists = listOf(buildPlaylist(), buildPlaylist(2))
         val exception = IllegalStateException("unexpected failure")
-        coEvery { repository.upsertPlaylists(playlists) } throws exception
+        coEvery { repository.upsertPlaylists(playlists, EMAIL) } throws exception
 
         val result = runCatching {
             useCase(playlists)
@@ -47,7 +56,9 @@ class UpsertPlaylistsUseCaseTest {
 
         result shouldBeEqualTo left(exception)
         coVerifyOnce {
-            repository.upsertPlaylists(playlists)
+            repository.upsertPlaylists(playlists, EMAIL)
         }
     }
 }
+
+private const val EMAIL = "test@test.com"


### PR DESCRIPTION
### :tophat: How was this resolved?

Cloud synchronization for playlists using Firestore.

Key changes:
- Integrated `CloudPlaylistDataSource` into `DefaultPlaylistRepository`.
- Updated playlist use cases to include user email for cloud operations.
- Implemented mappers for converting between local, cloud, and domain playlist models.
- Modified `LocalPlaylistDataSource` to handle playlist item positions correctly.
- Added tests to cover new cloud synchronization logic in repository and use cases.
- Injected `Context` into use cases to retrieve user email from DataStore.
- Added default values for `CloudPlaylistResponse` and `CloudPlaylistItemResponse`.
