### PR TITLE
Feature: Resume last played audio

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/data/local/mapper/ToAudioCourseMapper.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/data/local/mapper/ToAudioCourseMapper.kt
@@ -71,3 +71,26 @@ fun AudioCourseItemDbModel.toPlaylistAudioItem(
         playlistItemId = null,
         markedAsFavorite = markedAsFavorite,
     )
+
+fun AudioCourseItem.toPlaylistAudioItem(
+    audioCourse: AudioCourse,
+    position: Int,
+): PlaylistAudioItem =
+    PlaylistAudioItem(
+        id = id,
+        title = title,
+        description = audioCourse.title,
+        saga = audioCourse.saga,
+        url = url,
+        audioUrl = url,
+        imageUrl = audioCourse.thumbnailUrl,
+        thumbnailUrl = audioCourse.thumbnailUrl,
+        pubDateMillis = audioCourse.pubDateMillis,
+        audioLengthInSeconds = audioCourse.audioLengthInSeconds,
+        hasBeenListened = hasBeenListened,
+        category = audioCourse.category,
+        excerpt = audioCourse.excerpt,
+        position = position,
+        playlistItemId = null,
+        markedAsFavorite = markedAsFavorite,
+    )

--- a/gabimoreno/src/main/java/soy/gabimoreno/di/DataStoreModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/DataStoreModule.kt
@@ -9,11 +9,13 @@ import dagger.hilt.components.SingletonComponent
 import soy.gabimoreno.domain.session.MemberSession
 import soy.gabimoreno.domain.usecase.CheckShouldIShowInAppReviewUseCase
 import soy.gabimoreno.domain.usecase.GetInAppReviewCounterUseCase
+import soy.gabimoreno.domain.usecase.GetLastAudioListenedIdUseCase
 import soy.gabimoreno.domain.usecase.GetShouldIReversePodcastOrderUseCase
 import soy.gabimoreno.domain.usecase.IsBearerTokenValid
 import soy.gabimoreno.domain.usecase.ResetJwtAuthTokenUseCase
 import soy.gabimoreno.domain.usecase.SaveCredentialsInDataStoreUseCase
 import soy.gabimoreno.domain.usecase.SetJwtAuthTokenUseCase
+import soy.gabimoreno.domain.usecase.SetLastAudioListenedIdUseCase
 import soy.gabimoreno.domain.usecase.SetShouldIReversePodcastOrderUseCase
 import soy.gabimoreno.domain.usecase.SetShouldIShowInAppReviewUseCase
 import soy.gabimoreno.framework.datastore.DataStoreMemberSession
@@ -81,4 +83,16 @@ object DataStoreModule {
     fun provideSetShouldIShowInAppReviewUseCase(
         @ApplicationContext context: Context,
     ) = SetShouldIShowInAppReviewUseCase(context)
+
+    @Provides
+    @Singleton
+    fun provideGetLastAudioListenedIdUseCase(
+        @ApplicationContext context: Context,
+    ) = GetLastAudioListenedIdUseCase(context)
+
+    @Provides
+    @Singleton
+    fun provideSetLastAudioListenedIdUseCase(
+        @ApplicationContext context: Context,
+    ) = SetLastAudioListenedIdUseCase(context)
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/di/HomeModule.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/di/HomeModule.kt
@@ -4,8 +4,12 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
+import soy.gabimoreno.domain.repository.podcast.PodcastRepository
+import soy.gabimoreno.domain.repository.premiumaudios.PremiumAudiosRepository
 import soy.gabimoreno.domain.usecase.EncodeUrlUseCase
 import soy.gabimoreno.domain.usecase.GetAppVersionNameUseCase
+import soy.gabimoreno.domain.usecase.GetAudioByIdUseCase
 import soy.gabimoreno.domain.usecase.GetPodcastStreamUseCase
 import soy.gabimoreno.domain.usecase.GetShouldIReversePodcastOrderUseCase
 import soy.gabimoreno.domain.usecase.HomeUseCases
@@ -35,5 +39,17 @@ class HomeModule {
         getAppVersionName = getAppVersionNameUseCase,
         getShouldIReversePodcastOrder = getShouldIReversePodcastOrderUseCase,
         setShouldIReversePodcastOrder = setShouldIReversePodcastOrderUseCase,
+    )
+
+    @Provides
+    @Singleton
+    fun provideGetAudioByIdUseCase(
+        audioCoursesRepository: AudioCoursesRepository,
+        podcastRepository: PodcastRepository,
+        premiumAudiosRepository: PremiumAudiosRepository,
+    ) = GetAudioByIdUseCase(
+        audioCoursesRepository = audioCoursesRepository,
+        podcastRepository = podcastRepository,
+        premiumAudiosRepository = premiumAudiosRepository,
     )
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/audiocourses/AudioCoursesRepository.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/repository/audiocourses/AudioCoursesRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import soy.gabimoreno.data.remote.model.Category
 import soy.gabimoreno.domain.model.content.AudioCourse
 import soy.gabimoreno.domain.model.content.AudioCourseItem
+import soy.gabimoreno.domain.model.content.PlaylistAudioItem
 
 interface AudioCoursesRepository {
     suspend fun getCourses(
@@ -14,6 +15,9 @@ interface AudioCoursesRepository {
     ): Either<Throwable, List<AudioCourse>>
     suspend fun getCourseById(idCourse: String): Either<Throwable, Flow<AudioCourse>>
     suspend fun getAudioCourseItem(audioCourseItemId: String): Either<Throwable, AudioCourseItem>
+    suspend fun getAudioCourseItemById(
+        audioCourseItemId: String,
+    ): Either<Throwable, PlaylistAudioItem>
     suspend fun getAllFavoriteAudioCoursesItems(): Either<Throwable, List<AudioCourseItem>>
     suspend fun markAudioCourseItemAsListened(
         audioCourseId: String,

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetAudioByIdUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetAudioByIdUseCase.kt
@@ -1,0 +1,33 @@
+package soy.gabimoreno.domain.usecase
+
+import arrow.core.Either
+import soy.gabimoreno.domain.model.audio.Audio
+import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
+import soy.gabimoreno.domain.repository.podcast.PodcastRepository
+import soy.gabimoreno.domain.repository.premiumaudios.PremiumAudiosRepository
+import soy.gabimoreno.domain.util.AudioItemType
+import soy.gabimoreno.domain.util.audioItemTypeDetector
+import javax.inject.Inject
+
+class GetAudioByIdUseCase
+    @Inject
+    constructor(
+        private val audioCoursesRepository: AudioCoursesRepository,
+        private val podcastRepository: PodcastRepository,
+        private val premiumAudiosRepository: PremiumAudiosRepository,
+    ) {
+        suspend operator fun invoke(audioId: String): Either<Throwable, Audio> =
+            when (audioItemTypeDetector(audioId)) {
+                AudioItemType.AUDIO_COURSE -> {
+                    audioCoursesRepository.getAudioCourseItemById(audioId)
+                }
+
+                AudioItemType.PREMIUM_AUDIO -> {
+                    premiumAudiosRepository.getPremiumAudioById(audioId)
+                }
+
+                AudioItemType.PODCAST -> {
+                    podcastRepository.getPodcastById(audioId)
+                }
+            }
+    }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetLastAudioListenedIdUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/GetLastAudioListenedIdUseCase.kt
@@ -1,0 +1,14 @@
+package soy.gabimoreno.domain.usecase
+
+import android.content.Context
+import kotlinx.coroutines.flow.first
+import soy.gabimoreno.framework.datastore.dataStoreGetLastAudioListenedId
+import javax.inject.Inject
+
+class GetLastAudioListenedIdUseCase
+    @Inject
+    constructor(
+        private val context: Context,
+    ) {
+        suspend operator fun invoke(): String = context.dataStoreGetLastAudioListenedId().first()
+    }

--- a/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetLastAudioListenedIdUseCase.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/domain/usecase/SetLastAudioListenedIdUseCase.kt
@@ -1,0 +1,14 @@
+package soy.gabimoreno.domain.usecase
+
+import android.content.Context
+import soy.gabimoreno.framework.datastore.setDataStoreLastAudioListenedId
+import javax.inject.Inject
+
+class SetLastAudioListenedIdUseCase
+    @Inject
+    constructor(
+        private val context: Context,
+    ) {
+        suspend operator fun invoke(audioId: String) =
+            context.setDataStoreLastAudioListenedId(audioId)
+    }

--- a/gabimoreno/src/main/java/soy/gabimoreno/framework/datastore/DataStoreLastAudioListened.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/framework/datastore/DataStoreLastAudioListened.kt
@@ -1,0 +1,23 @@
+package soy.gabimoreno.framework.datastore
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+fun Context.dataStoreGetLastAudioListenedId(): Flow<String> =
+    dataStore.data
+        .map { preferences ->
+            preferences[key] ?: DEFAULT_LAST_AUDIO_LISTENED_ID
+        }
+
+suspend fun Context.setDataStoreLastAudioListenedId(audioId: String) {
+    dataStore.edit { settings ->
+        settings[key] = audioId
+    }
+}
+
+private const val DEFAULT_LAST_AUDIO_LISTENED_ID = "0"
+private const val LAST_AUDIO_LISTENED_ID = "LAST_AUDIO_LISTENED_ID"
+private val key = stringPreferencesKey(LAST_AUDIO_LISTENED_ID)

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/GetAudioByIdUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/GetAudioByIdUseCaseTest.kt
@@ -1,0 +1,95 @@
+package soy.gabimoreno.domain.usecase
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Before
+import org.junit.Test
+import soy.gabimoreno.core.testing.coVerifyNever
+import soy.gabimoreno.core.testing.coVerifyOnce
+import soy.gabimoreno.domain.repository.audiocourses.AudioCoursesRepository
+import soy.gabimoreno.domain.repository.podcast.PodcastRepository
+import soy.gabimoreno.domain.repository.premiumaudios.PremiumAudiosRepository
+import soy.gabimoreno.ext.right
+import soy.gabimoreno.fake.buildAudioItem
+import soy.gabimoreno.fake.buildEpisode
+import soy.gabimoreno.fake.buildPremiumAudio
+
+class GetAudioByIdUseCaseTest {
+    private val audioCoursesRepository: AudioCoursesRepository = mockk()
+    private val podcastRepository: PodcastRepository = mockk()
+    private val premiumAudiosRepository: PremiumAudiosRepository = mockk()
+
+    private lateinit var useCase: GetAudioByIdUseCase
+
+    @Before
+    fun setUp() {
+        useCase =
+            GetAudioByIdUseCase(
+                audioCoursesRepository,
+                podcastRepository,
+                premiumAudiosRepository,
+            )
+    }
+
+    @Test
+    fun `GIVEN audioCourseId WHEN invoke THEN audioCoursesRepository is called`() =
+        runTest {
+            val audioId = "123-1"
+            val audioCourseItem = buildAudioItem(audioId)
+            val expected = right(audioCourseItem)
+            coEvery { audioCoursesRepository.getAudioCourseItemById(audioId) } returns expected
+
+            val result = useCase(audioId)
+
+            result shouldBeEqualTo expected
+            coVerifyOnce {
+                audioCoursesRepository.getAudioCourseItemById(audioId)
+            }
+            coVerifyNever {
+                premiumAudiosRepository.getPremiumAudioById(any())
+                podcastRepository.getPodcastById(any())
+            }
+        }
+
+    @Test
+    fun `GIVEN premiumAudioId WHEN invoke THEN premiumAudiosRepository is called`() =
+        runTest {
+            val audioId = "1"
+            val premiumAudio = buildPremiumAudio(audioId)
+            val expected = right(premiumAudio)
+            coEvery { premiumAudiosRepository.getPremiumAudioById(audioId) } returns expected
+
+            val result = useCase(audioId)
+
+            result shouldBeEqualTo expected
+            coVerifyOnce {
+                premiumAudiosRepository.getPremiumAudioById(audioId)
+            }
+            coVerifyNever {
+                audioCoursesRepository.getAudioCourseItemById(any())
+                podcastRepository.getPodcastById(any())
+            }
+        }
+
+    @Test
+    fun `GIVEN podcastId WHEN invoke THEN podcastRepository is called`() =
+        runTest {
+            val audioId = "123e4567-e89b-12d3-a456-426614174000"
+            val podcast = buildEpisode(audioId)
+            val expected = right(podcast)
+            coEvery { podcastRepository.getPodcastById(audioId) } returns expected
+
+            val result = useCase(audioId)
+
+            result shouldBeEqualTo expected
+            coVerifyOnce {
+                podcastRepository.getPodcastById(audioId)
+            }
+            coVerifyNever {
+                audioCoursesRepository.getAudioCourseItemById(any())
+                premiumAudiosRepository.getPremiumAudioById(any())
+            }
+        }
+}

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/GetLastAudioListenedIdUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/GetLastAudioListenedIdUseCaseTest.kt
@@ -1,0 +1,68 @@
+package soy.gabimoreno.domain.usecase
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import io.mockk.coJustRun
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import soy.gabimoreno.framework.datastore.dataStore
+import soy.gabimoreno.framework.datastore.setDataStoreLastAudioListenedId
+
+class GetLastAudioListenedIdUseCaseTest {
+    private val context: Context = mockk()
+    private val dataStore: DataStore<Preferences> = mockk()
+    private val preferences: Preferences = mockk()
+
+    private lateinit var useCase: GetLastAudioListenedIdUseCase
+    private val key = stringPreferencesKey(LAST_AUDIO_LISTENED_ID)
+
+    @Before
+    fun setUp() {
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreKt")
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreLastAudioListenedKt")
+        every { context.dataStore } returns dataStore
+        every { dataStore.data } returns flowOf(preferences)
+        coJustRun { context.setDataStoreLastAudioListenedId(any()) }
+        useCase = GetLastAudioListenedIdUseCase(context)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic("soy.gabimoreno.framework.datastore.DataStoreKt")
+        unmockkStatic("soy.gabimoreno.framework.datastore.DataStoreLastAudioListenedKt")
+    }
+
+    @Test
+    fun `GIVEN no preference stored WHEN invoke THEN uses default value`() =
+        runTest {
+            every { preferences[key] } returns DEFAULT_LAST_AUDIO_LISTENED_ID
+
+            val result = useCase()
+
+            result shouldBeEqualTo DEFAULT_LAST_AUDIO_LISTENED_ID
+        }
+
+    @Test
+    fun `GIVEN preference stored WHEN invoke THEN returns value`() =
+        runTest {
+            val audioId = "1"
+            every { preferences[key] } returns audioId
+
+            val result = useCase()
+
+            result shouldBeEqualTo audioId
+        }
+}
+
+private const val DEFAULT_LAST_AUDIO_LISTENED_ID = "0"
+private const val LAST_AUDIO_LISTENED_ID = "LAST_AUDIO_LISTENED_ID"

--- a/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/SetLastAudioListenedIdUseCaseTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/domain/usecase/SetLastAudioListenedIdUseCaseTest.kt
@@ -1,0 +1,54 @@
+package soy.gabimoreno.domain.usecase
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import io.mockk.coJustRun
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import soy.gabimoreno.core.testing.coVerifyOnce
+import soy.gabimoreno.framework.datastore.dataStore
+import soy.gabimoreno.framework.datastore.setDataStoreLastAudioListenedId
+
+class SetLastAudioListenedIdUseCaseTest {
+    private val context: Context = mockk()
+    private val dataStore: DataStore<Preferences> = mockk()
+    private val preferences: Preferences = mockk()
+
+    private lateinit var useCase: SetLastAudioListenedIdUseCase
+
+    @Before
+    fun setUp() {
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreKt")
+        mockkStatic("soy.gabimoreno.framework.datastore.DataStoreLastAudioListenedKt")
+        every { context.dataStore } returns dataStore
+        every { dataStore.data } returns flowOf(preferences)
+        coJustRun { context.setDataStoreLastAudioListenedId(any()) }
+        useCase = SetLastAudioListenedIdUseCase(context)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic("soy.gabimoreno.framework.datastore.DataStoreKt")
+        unmockkStatic("soy.gabimoreno.framework.datastore.DataStoreLastAudioListenedKt")
+    }
+
+    @Test
+    fun `GIVEN audioId WHEN invoke THEN set preference`() =
+        runTest {
+            val audioId = "1"
+
+            useCase(audioId)
+
+            coVerifyOnce {
+                context.setDataStoreLastAudioListenedId(audioId)
+            }
+        }
+}

--- a/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/player/PlayerViewModelTest.kt
+++ b/gabimoreno/src/test/java/soy/gabimoreno/presentation/screen/player/PlayerViewModelTest.kt
@@ -1,6 +1,7 @@
 package soy.gabimoreno.presentation.screen.player
 
 import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -19,9 +20,12 @@ import soy.gabimoreno.data.tracker.main.PlayerTrackerEvent
 import soy.gabimoreno.data.tracker.toMap
 import soy.gabimoreno.domain.model.audio.Audio
 import soy.gabimoreno.domain.usecase.CheckShouldIShowInAppReviewUseCase
+import soy.gabimoreno.domain.usecase.GetAudioByIdUseCase
+import soy.gabimoreno.domain.usecase.GetLastAudioListenedIdUseCase
 import soy.gabimoreno.domain.usecase.MarkAudioCourseItemAsListenedUseCase
 import soy.gabimoreno.domain.usecase.MarkPodcastAsListenedUseCase
 import soy.gabimoreno.domain.usecase.MarkPremiumAudioAsListenedUseCase
+import soy.gabimoreno.domain.usecase.SetLastAudioListenedIdUseCase
 import soy.gabimoreno.fake.buildAudio
 import soy.gabimoreno.fake.buildAudios
 import soy.gabimoreno.player.service.MediaPlayerServiceConnection
@@ -30,13 +34,16 @@ import soy.gabimoreno.player.service.MediaPlayerServiceConnection
 class PlayerViewModelTest {
     private val tracker: Tracker = relaxedMockk()
     private val mediaPlayerServiceConnection: MediaPlayerServiceConnection = relaxedMockk()
-    private val markAudioCourseItemAsListenedUseCase =
+    private val markAudioCourseAsListenedUseCase =
         relaxedMockk<MarkAudioCourseItemAsListenedUseCase>()
     private val markPremiumAudioAsListenedUseCase =
         relaxedMockk<MarkPremiumAudioAsListenedUseCase>()
     private val markPodcastAsListenedUseCase = relaxedMockk<MarkPodcastAsListenedUseCase>()
     private val checkShouldIShowInAppReviewUseCase =
         relaxedMockk<CheckShouldIShowInAppReviewUseCase>()
+    private val setLastAudioListenedIdUseCase: SetLastAudioListenedIdUseCase = mockk()
+    private val getLastAudioListenedIdUseCase: GetLastAudioListenedIdUseCase = mockk()
+    private val getAudioByIdUseCase: GetAudioByIdUseCase = mockk()
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
     private lateinit var viewModel: PlayerViewModel
 
@@ -45,13 +52,16 @@ class PlayerViewModelTest {
         Dispatchers.setMain(testDispatcher)
         viewModel =
             PlayerViewModel(
-                mediaPlayerServiceConnection,
-                tracker,
-                markAudioCourseItemAsListenedUseCase,
-                markPodcastAsListenedUseCase,
-                markPremiumAudioAsListenedUseCase,
-                checkShouldIShowInAppReviewUseCase,
-                testDispatcher,
+                checkShouldIShowInAppReviewUseCase = checkShouldIShowInAppReviewUseCase,
+                getAudioByIdUseCase = getAudioByIdUseCase,
+                getLastAudioListenedIdUseCase = getLastAudioListenedIdUseCase,
+                markAudioCourseAsListenedUseCase = markAudioCourseAsListenedUseCase,
+                markPodcastAsListenedUseCase = markPodcastAsListenedUseCase,
+                markPremiumAudioAsListenedUseCase = markPremiumAudioAsListenedUseCase,
+                mediaPlayerServiceConnection = mediaPlayerServiceConnection,
+                setLastAudioListenedIdUseCase = setLastAudioListenedIdUseCase,
+                tracker = tracker,
+                dispatcher = testDispatcher,
             )
     }
 


### PR DESCRIPTION
### :tophat: How was this resolved?

This commit introduces the ability to resume the last played audio when the app is reopened.

Key changes:
- Added `GetLastAudioListenedIdUseCase` and `SetLastAudioListenedIdUseCase` to manage the last played audio ID in DataStore.
- Implemented `DataStoreLastAudioListened.kt` for DataStore interactions.
- Added `GetAudioByIdUseCase` to retrieve audio details by ID from different repositories (AudioCourses, Podcast, PremiumAudios).
- Updated `PlayerViewModel` to fetch and play the last listened audio on initialization.
- Added `toPlaylistAudioItem` mapper for `AudioCourseItem`.
- Updated DI modules to provide the new use cases.
- Added unit tests for the new use cases and repository changes.
