### PR TITLE
Refactor: Applied the designer's suggestions

### DIFF
--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/navigation/AppNavigation.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/navigation/AppNavigation.kt
@@ -73,6 +73,9 @@ private fun NavGraphBuilder.podcastNav(
                 onBackClicked = {
                     navController.goBack()
                 },
+                onAddToPlaylistClicked = { audioItemId ->
+                    navController.navigateToPlaylistAudioItem(audioItemId = audioItemId)
+                },
             )
         }
 
@@ -125,6 +128,9 @@ private fun NavGraphBuilder.premiumNav(
                 Feature.PREMIUM,
                 onBackClicked = {
                     navController.goBack()
+                },
+                onAddToPlaylistClicked = { audioItemId ->
+                    navController.navigateToPlaylistAudioItem(audioItemId = audioItemId)
                 },
             )
         }

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/courses/detail/AudioCourseDetailScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/courses/detail/AudioCourseDetailScreen.kt
@@ -149,8 +149,6 @@ fun AudioCourseDetailScreen(
                             .background(PurpleDark.copy(alpha = 0.8f)),
                 ) {
                     BackButton(
-                        modifier = Modifier.size(Spacing.s64),
-                        tint = Orange,
                         onClick = { onAction(AudioCourseDetailAction.OnBackClicked) },
                     )
                 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/detail/DetailScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/detail/DetailScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.LibraryMusic
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -63,6 +64,7 @@ import soy.gabimoreno.util.toDurationMinutes
 fun DetailScreen(
     audioId: String,
     feature: Feature,
+    onAddToPlaylistClicked: (audioId: String) -> Unit,
     onBackClicked: () -> Unit,
 ) {
     val currentContext = LocalContext.current
@@ -226,6 +228,26 @@ fun DetailScreen(
                                 )
                             }
                             Spacer(modifier = Modifier.width(Spacing.s16))
+                            IconButton(
+                                modifier = Modifier.size(Spacing.s32),
+                                onClick = {
+                                    onAddToPlaylistClicked(
+                                        detailViewModel.audioState?.id ?: "",
+                                    )
+                                },
+                            ) {
+                                Icon(
+                                    modifier =
+                                        Modifier
+                                            .size(Spacing.s32),
+                                    imageVector = Icons.Default.LibraryMusic,
+                                    contentDescription =
+                                        stringResource(
+                                            R.string.playlists_add_audio_to_playlist,
+                                        ),
+                                    tint = White,
+                                )
+                            }
                         }
 
                         AnimatedIconButton(

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/detail/PlaylistDetailScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/detail/PlaylistDetailScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.PlayCircleOutline
 import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.runtime.Composable
@@ -36,7 +35,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -54,6 +52,7 @@ import soy.gabimoreno.presentation.theme.PurpleDark
 import soy.gabimoreno.presentation.theme.PurpleLight
 import soy.gabimoreno.presentation.theme.Spacing
 import soy.gabimoreno.presentation.theme.White
+import soy.gabimoreno.presentation.ui.BackButton
 import soy.gabimoreno.presentation.ui.dialog.CustomDialog
 import soy.gabimoreno.presentation.ui.dialog.TypeDialog
 
@@ -160,11 +159,13 @@ private fun PlaylistDetailHeader(
                     .height(200.dp),
         )
 
-        IconOverlay(
-            icon = Icons.AutoMirrored.Filled.ArrowBack,
-            contentDescription = stringResource(R.string.back),
+        BackButton(
             onClick = { onAction(PlaylistDetailAction.OnBackClicked) },
-            modifier = Modifier.align(Alignment.TopStart),
+            modifier =
+                Modifier
+                    .windowInsetsPadding(
+                        WindowInsets.safeDrawing.only(WindowInsetsSides.Top),
+                    ).align(Alignment.TopStart),
         )
 
         if (state.playlistAudioItems.isNotEmpty()) {
@@ -267,7 +268,6 @@ private fun PlaylistEmptyState() {
             text = stringResource(R.string.playlist_add_items),
             style = MaterialTheme.typography.h6,
             color = Orange,
-            textDecoration = TextDecoration.Underline,
         )
     }
 }

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/list/PlaylistScreen.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/screen/playlist/list/PlaylistScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -31,7 +30,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -122,7 +120,7 @@ private fun PlaylistToolbar(onBackClick: () -> Unit) {
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(Spacing.s96),
+                .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Top)),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         IconButton(
@@ -188,7 +186,6 @@ private fun PlaylistEmptyContent() {
                     SpanStyle(
                         color = Orange,
                         fontWeight = FontWeight.Bold,
-                        textDecoration = TextDecoration.Underline,
                     ),
                 ) {
                     append(stringResource(R.string.playlists_name).uppercase())

--- a/gabimoreno/src/main/java/soy/gabimoreno/presentation/ui/BackButton.kt
+++ b/gabimoreno/src/main/java/soy/gabimoreno/presentation/ui/BackButton.kt
@@ -1,16 +1,9 @@
 package soy.gabimoreno.presentation.ui
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import soy.gabimoreno.R
 import soy.gabimoreno.presentation.theme.Spacing
@@ -18,18 +11,13 @@ import soy.gabimoreno.presentation.theme.Spacing
 @Composable
 fun BackButton(
     modifier: Modifier = Modifier,
-    tint: Color = MaterialTheme.colors.onBackground,
     onClick: () -> Unit,
 ) {
-    Icon(
-        Icons.AutoMirrored.Filled.ArrowBack,
+    IconButton(
+        modifier = modifier,
+        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
         contentDescription = stringResource(R.string.back),
-        tint = tint,
-        modifier =
-            modifier
-                .padding(top = Spacing.s8, start = Spacing.s8)
-                .clip(CircleShape)
-                .clickable(onClick = onClick)
-                .padding(Spacing.s8),
+        padding = Spacing.s16,
+        onClick = onClick,
     )
 }


### PR DESCRIPTION
### :tophat: How was this resolved?

Improve UI consistency in playlist and detail screens

This commit refactors the UI in several screens:

- PlaylistScreen:
    - Uses `windowInsetsPadding` for the top bar.
    - Removes underline from "PLAYLISTS" title.
- PlaylistDetailScreen:
    - Uses a common `BackButton` Composable.
    - Removes underline from "ADD ITEMS" text.
- AppNavigation:
    - Adds `onAddToPlaylistClicked` navigation to `DetailScreen` and `EpisodesScreen`.
- DetailScreen:
    - Adds an "Add to Playlist" icon button.
- AudioCourseDetailScreen:
    - Simplifies `BackButton` usage.
- BackButton:
    - Refactors `BackButton` to use a common `IconButton` and removes custom styling.