### PR TITLE
fix: show correct success toast after premium reset

### DIFF
--- a/app/src/main/java/soy/gabimoreno/presentation/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/soy/gabimoreno/presentation/screen/profile/ProfileScreen.kt
@@ -60,7 +60,7 @@ fun ProfileScreenRoot(
     val profileResetSuccessAudioCoursesMessage =
         stringResource(R.string.profile_reset_success_audio_courses)
     val profileResetSuccessPodcastMessage = stringResource(R.string.profile_reset_success_podcast)
-    val profileResetSuccessPremiumMessage = stringResource(R.string.unexpected_error)
+    val profileResetSuccessPremiumMessage = stringResource(R.string.profile_reset_success_premium)
     val profileViewModel = ViewModelProvider.profileViewModel
     LaunchedEffect(Unit) {
         launch {


### PR DESCRIPTION
### :tophat: How was this resolved?

Updated the Profile screen to use the premium reset success string instead of the generic unexpected error message when the premium reset completes successfully.
