### PR TITLE
fix: missing Kluent test dependency to feature/auth module

### DIFF
--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(libs.google.material)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kluent.android)
 
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.espresso.core)


### PR DESCRIPTION
### :tophat: How was this resolved?

Added missing Kluent test dependency to feature/auth module
